### PR TITLE
Add AssignLaunchPadCommand test and handler

### DIFF
--- a/example/RocketLaunch.Application.Tests/AssignLaunchPadCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/AssignLaunchPadCommandTests.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class AssignLaunchPadCommandTests
+{
+    [Fact]
+    public async Task Handle_AssignLaunchPadCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+
+        var eventStore = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(eventStore);
+
+        var registerMissionHandler = new RegisterMissionCommandHandler(repository);
+        var registerMissionCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Above Surface of the Moon",
+            payloadDescription: "Rover, 250kg",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+
+        await registerMissionHandler.HandleCommandAsync(registerMissionCommand);
+
+        var assignRocketHandler = new AssignRocketCommandHandler(repository, validator);
+        var assignRocketCommand = new AssignRocketCommand(
+            missionId: registerMissionCommand.MissionId,
+            rocketId: Guid.NewGuid()
+        );
+        await assignRocketHandler.HandleCommandAsync(assignRocketCommand);
+
+        var assignPadHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        var padId = Guid.NewGuid();
+        var assignPadCommand = new AssignLaunchPadCommand(
+            missionId: registerMissionCommand.MissionId,
+            launchPadId: padId
+        );
+        await assignPadHandler.HandleCommandAsync(assignPadCommand);
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerMissionCommand.MissionId));
+
+        Debug.Assert(mission != null, nameof(mission) + " != null");
+        Assert.NotNull(mission.AssignedPad);
+        Assert.Equal(padId, mission.AssignedPad.Value);
+        Assert.Equal(2, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/AssignLaunchPadCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/AssignLaunchPadCommandHandler.cs
@@ -1,0 +1,31 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.Domain.Service;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class AssignLaunchPadCommandHandler(IEventSourcingRepository repository, IResourceAvailabilityService validator)
+    : CommandHandler<AssignLaunchPadCommand>(repository)
+{
+    public override async Task HandleCommandAsync(AssignLaunchPadCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        await mission.AssignLaunchPadAsync(new LaunchPadId(command.LaunchPadId), validator);
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AssignLaunchPadCommandHandler`
- add application test for assigning launch pad

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9dfba68483289a1091db0b4050dc