### PR TITLE
Implement AssignCrewCommandHandler with tests

### DIFF
--- a/example/RocketLaunch.Application.Tests/AssignCrewCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/AssignCrewCommandTests.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class AssignCrewCommandTests
+{
+    [Fact]
+    public async Task Handle_AssignCrewCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+
+        var eventStore = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(eventStore);
+
+        var registerMissionHandler = new RegisterMissionCommandHandler(repository);
+        var registerMissionCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Above Surface of the Moon",
+            payloadDescription: "Rover, 250kg",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+        await registerMissionHandler.HandleCommandAsync(registerMissionCommand);
+
+        var assignRocketHandler = new AssignRocketCommandHandler(repository, validator);
+        await assignRocketHandler.HandleCommandAsync(new AssignRocketCommand(
+            missionId: registerMissionCommand.MissionId,
+            rocketId: Guid.NewGuid()
+        ));
+
+        var assignPadHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        await assignPadHandler.HandleCommandAsync(new AssignLaunchPadCommand(
+            missionId: registerMissionCommand.MissionId,
+            launchPadId: Guid.NewGuid()
+        ));
+
+        var assignCrewHandler = new AssignCrewCommandHandler(repository, validator);
+        var crewIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        await assignCrewHandler.HandleCommandAsync(new AssignCrewCommand(
+            missionId: registerMissionCommand.MissionId,
+            crewMemberIds: crewIds
+        ));
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerMissionCommand.MissionId));
+
+        Debug.Assert(mission != null, nameof(mission) + " != null");
+        Assert.Equal(crewIds.Length, mission!.Crew.Count);
+        foreach (var id in crewIds)
+        {
+            Assert.Contains(mission.Crew, m => m.Value == id);
+        }
+        Assert.Equal(3, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/AssignCrewCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/AssignCrewCommandHandler.cs
@@ -1,0 +1,31 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.Domain.Service;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class AssignCrewCommandHandler(IEventSourcingRepository repository, IResourceAvailabilityService validator)
+    : CommandHandler<AssignCrewCommand>(repository)
+{
+    public override async Task HandleCommandAsync(AssignCrewCommand command)
+    {
+        Mission mission;
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        var crew = command.CrewMemberIds.Select(id => new CrewMemberId(id));
+        await mission.AssignCrewAsync(crew, validator);
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -36,6 +36,8 @@ namespace RocketLaunch.Application
             _commandProcessor.RegisterHandlerFactory(() => new AssignRocketCommandHandler(repository, _validator));
             _commandProcessor.RegisterHandlerFactory(
                 () => new AssignLaunchPadCommandHandler(repository, _validator));
+            _commandProcessor.RegisterHandlerFactory(
+                () => new AssignCrewCommandHandler(repository, _validator));
         }
 
         public async Task<ICommandExecutionResult> ExecuteAsync<TCommand>(TCommand command)


### PR DESCRIPTION
## Summary
- add `AssignCrewCommandHandler` and register it
- include application level tests for assigning crew

## Testing
- `dotnet test` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_686aa0ec2be483289cf5e9b523ca1613