### PR TITLE
Fix CrewMember aggregate with events

### DIFF
--- a/example/RocketLaunch.Domain.Tests/CrewMemberTests.cs
+++ b/example/RocketLaunch.Domain.Tests/CrewMemberTests.cs
@@ -2,8 +2,10 @@
 
 using RocketLaunch.Domain.Model;
 using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.Events.CrewMember;
 using RocketLaunch.SharedKernel.ValueObjects;
 using Xunit;
+using System.Linq;
 
 namespace RocketLaunch.Domain.Tests;
 
@@ -26,7 +28,12 @@ public class CrewMemberTests
     public void Assign_WhenAvailable_SetsAssigned()
     {
         var member = new CrewMember(new CrewMemberId(Guid.NewGuid()), "Bob", CrewRole.Pilot, Array.Empty<string>());
+
         member.Assign();
+
+        var events = member.GetUncommittedChanges().ToList();
+        Assert.Single(events);
+        Assert.IsType<AssignCrewMember>(events[0]);
         Assert.Equal(CrewMemberStatus.Assigned, member.Status);
     }
 
@@ -42,7 +49,13 @@ public class CrewMemberTests
     public void SetCertifications_ReplacesList()
     {
         var member = new CrewMember(new CrewMemberId(Guid.NewGuid()), "Bob", CrewRole.Pilot, new[] { "A" });
+
         member.SetCertifications(new[] { "B", "C" });
+
+        var events = member.GetUncommittedChanges().ToList();
+        Assert.Single(events);
+        var evt = Assert.IsType<SetCertificationForCrewMember>(events[0]);
+        Assert.Equal(new[] { "B", "C" }, evt.Certifications);
         Assert.Equal(new[] { "B", "C" }, member.Certifications);
     }
 }

--- a/example/RocketLaunch.SharedKernel/Events/CrewMember/AssignCrewMember.cs
+++ b/example/RocketLaunch.SharedKernel/Events/CrewMember/AssignCrewMember.cs
@@ -1,0 +1,21 @@
+// Domain/Events/CrewMember/AssignCrewMember.cs
+
+using DDD.BuildingBlocks.Core.Attribute;
+using DDD.BuildingBlocks.Core.Event;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.SharedKernel.Events.CrewMember;
+
+[DomainEventType]
+public sealed class AssignCrewMember : DomainEvent
+{
+    private const int CurrentClassVersion = 1;
+
+    public CrewMemberId CrewMemberId { get; }
+
+    public AssignCrewMember(CrewMemberId crewMemberId, int targetVersion = -1)
+        : base(crewMemberId.Value.ToString(), targetVersion, CurrentClassVersion)
+    {
+        CrewMemberId = crewMemberId;
+    }
+}

--- a/example/RocketLaunch.SharedKernel/Events/CrewMember/ReleaseCrewMember.cs
+++ b/example/RocketLaunch.SharedKernel/Events/CrewMember/ReleaseCrewMember.cs
@@ -1,0 +1,21 @@
+// Domain/Events/CrewMember/ReleaseCrewMember.cs
+
+using DDD.BuildingBlocks.Core.Attribute;
+using DDD.BuildingBlocks.Core.Event;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.SharedKernel.Events.CrewMember;
+
+[DomainEventType]
+public sealed class ReleaseCrewMember : DomainEvent
+{
+    private const int CurrentClassVersion = 1;
+
+    public CrewMemberId CrewMemberId { get; }
+
+    public ReleaseCrewMember(CrewMemberId crewMemberId, int targetVersion = -1)
+        : base(crewMemberId.Value.ToString(), targetVersion, CurrentClassVersion)
+    {
+        CrewMemberId = crewMemberId;
+    }
+}

--- a/example/RocketLaunch.SharedKernel/Events/CrewMember/SetCertificationForCrewMember.cs
+++ b/example/RocketLaunch.SharedKernel/Events/CrewMember/SetCertificationForCrewMember.cs
@@ -1,0 +1,26 @@
+// Domain/Events/CrewMember/SetCertificationForCrewMember.cs
+
+using DDD.BuildingBlocks.Core.Attribute;
+using DDD.BuildingBlocks.Core.Event;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.SharedKernel.Events.CrewMember;
+
+[DomainEventType]
+public sealed class SetCertificationForCrewMember : DomainEvent
+{
+    private const int CurrentClassVersion = 1;
+
+    public CrewMemberId CrewMemberId { get; }
+    public IReadOnlyCollection<string> Certifications { get; }
+
+    public SetCertificationForCrewMember(
+        CrewMemberId crewMemberId,
+        IEnumerable<string> certifications,
+        int targetVersion = -1)
+        : base(crewMemberId.Value.ToString(), targetVersion, CurrentClassVersion)
+    {
+        CrewMemberId = crewMemberId;
+        Certifications = new List<string>(certifications).AsReadOnly();
+    }
+}

--- a/example/RocketLaunch.SharedKernel/Events/CrewMember/SetStatusForCrewMember.cs
+++ b/example/RocketLaunch.SharedKernel/Events/CrewMember/SetStatusForCrewMember.cs
@@ -1,0 +1,24 @@
+// Domain/Events/CrewMember/SetStatusForCrewMember.cs
+
+using DDD.BuildingBlocks.Core.Attribute;
+using DDD.BuildingBlocks.Core.Event;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.SharedKernel.Events.CrewMember;
+
+[DomainEventType]
+public sealed class SetStatusForCrewMember : DomainEvent
+{
+    private const int CurrentClassVersion = 1;
+
+    public CrewMemberId CrewMemberId { get; }
+    public CrewMemberStatus Status { get; }
+
+    public SetStatusForCrewMember(CrewMemberId crewMemberId, CrewMemberStatus status, int targetVersion = -1)
+        : base(crewMemberId.Value.ToString(), targetVersion, CurrentClassVersion)
+    {
+        CrewMemberId = crewMemberId;
+        Status = status;
+    }
+}


### PR DESCRIPTION
## Summary
- implement domain events for CrewMember
- refactor CrewMember aggregate to use ApplyEvent pattern
- update CrewMember domain tests to validate events

## Testing
- `dotnet test example/RocketLaunch.Domain.Tests/RocketLaunch.Domain.Tests.csproj --no-build --verbosity minimal`
- `dotnet test example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_686ab3d73b4c8328b88172a5972ddddd