### PR TITLE
Add station availability service tests

### DIFF
--- a/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RocketLaunch.ReadModel.Core.Builder;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.Events.Mission;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class CrewMemberProjectorTests
+{
+    [Fact]
+    public async Task CrewAssigned_marks_members_assigned()
+    {
+        var service = new InMemoryCrewService();
+        var projector = new CrewMemberProjector(service, NullLogger<CrewMemberProjector>.Instance);
+
+        var memberId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new CrewMember
+        {
+            CrewMemberId = memberId,
+            Name = "Alice",
+            Role = "Commander",
+            Status = CrewMemberStatus.Available
+        });
+
+        var missionId = Guid.NewGuid();
+        await projector.WhenAsync(new CrewAssigned(new MissionId(missionId), new[] { new CrewMemberId(memberId) }));
+
+        var member = service.GetById(memberId)!;
+        Assert.Equal(CrewMemberStatus.Assigned, member.Status);
+        Assert.Equal(missionId, member.AssignedMissionId);
+    }
+
+    [Fact]
+    public async Task MissionAborted_releases_crew_members()
+    {
+        var service = new InMemoryCrewService();
+        var projector = new CrewMemberProjector(service, NullLogger<CrewMemberProjector>.Instance);
+
+        var memberId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new CrewMember
+        {
+            CrewMemberId = memberId,
+            Name = "Bob",
+            Role = "Pilot",
+            Status = CrewMemberStatus.Assigned,
+            AssignedMissionId = Guid.NewGuid()
+        });
+        var missionId = service.GetById(memberId)!.AssignedMissionId!.Value;
+
+        await projector.WhenAsync(new MissionAborted(new MissionId(missionId)));
+
+        var member = service.GetById(memberId)!;
+        Assert.Equal(CrewMemberStatus.Available, member.Status);
+        Assert.Null(member.AssignedMissionId);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/LaunchPadProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/LaunchPadProjectorTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RocketLaunch.ReadModel.Core.Builder;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.Events.Mission;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class LaunchPadProjectorTests
+{
+    [Fact]
+    public async Task LaunchPadAssigned_marks_pad_occupied()
+    {
+        var service = new InMemoryLaunchPadService();
+        var projector = new LaunchPadProjector(service, NullLogger<LaunchPadProjector>.Instance);
+
+        var padId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new LaunchPad
+        {
+            LaunchPadId = padId,
+            PadName = "Pad A",
+            Status = LaunchPadStatus.Available
+        });
+
+        var missionId = Guid.NewGuid();
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+
+        await projector.WhenAsync(new LaunchPadAssigned(new MissionId(missionId), new LaunchPadId(padId), window));
+
+        var pad = service.GetById(padId)!;
+        Assert.Equal(LaunchPadStatus.Occupied, pad.Status);
+        Assert.Single(pad.OccupiedWindows);
+        var scheduled = pad.OccupiedWindows[0];
+        Assert.Equal(missionId, scheduled.MissionId);
+        Assert.Equal(window.Start, scheduled.Start);
+        Assert.Equal(window.End, scheduled.End);
+    }
+
+    [Fact]
+    public async Task MissionAborted_releases_launch_pad()
+    {
+        var service = new InMemoryLaunchPadService();
+        var projector = new LaunchPadProjector(service, NullLogger<LaunchPadProjector>.Instance);
+
+        var padId = Guid.NewGuid();
+        var missionId = Guid.NewGuid();
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        await service.CreateOrUpdateAsync(new LaunchPad
+        {
+            LaunchPadId = padId,
+            PadName = "Pad B",
+            Status = LaunchPadStatus.Occupied,
+            OccupiedWindows =
+            [
+                new ScheduledLaunchWindow
+                {
+                    MissionId = missionId,
+                    Start = window.Start,
+                    End = window.End
+                }
+            ]
+        });
+
+        await projector.WhenAsync(new MissionAborted(new MissionId(missionId)));
+
+        var pad = service.GetById(padId)!;
+        Assert.Equal(LaunchPadStatus.Available, pad.Status);
+        Assert.Empty(pad.OccupiedWindows);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/RocketLaunch.ReadModel.Tests.csproj
+++ b/example/RocketLaunch.ReadModel.Tests/RocketLaunch.ReadModel.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RocketLaunch.ReadModel.Core\RocketLaunch.ReadModel.Core.csproj" />
+    <ProjectReference Include="..\RocketLaunch.ReadModel.InMemory\RocketLaunch.ReadModel.InMemory.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/example/RocketLaunch.ReadModel.Tests/RocketProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/RocketProjectorTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RocketLaunch.ReadModel.Core.Builder;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.Events.Mission;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class RocketProjectorTests
+{
+    [Fact]
+    public async Task RocketAssigned_marks_rocket_assigned()
+    {
+        var service = new InMemoryRocketService();
+        var projector = new RocketProjector(service, NullLogger<RocketProjector>.Instance);
+
+        var rocketId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new Rocket
+        {
+            RocketId = rocketId,
+            RocketName = "Saturn",
+            Status = RocketStatus.Available
+        });
+
+        var missionId = Guid.NewGuid();
+        await projector.WhenAsync(new RocketAssigned(new MissionId(missionId), new RocketId(rocketId)));
+
+        var rocket = service.GetById(rocketId)!;
+        Assert.Equal(RocketStatus.Assigned, rocket.Status);
+        Assert.Equal(missionId, rocket.AssignedMissionId);
+    }
+
+    [Fact]
+    public async Task MissionAborted_releases_rocket()
+    {
+        var service = new InMemoryRocketService();
+        var projector = new RocketProjector(service, NullLogger<RocketProjector>.Instance);
+
+        var rocketId = Guid.NewGuid();
+        var missionId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new Rocket
+        {
+            RocketId = rocketId,
+            RocketName = "Saturn",
+            Status = RocketStatus.Assigned,
+            AssignedMissionId = missionId
+        });
+
+        await projector.WhenAsync(new MissionAborted(new MissionId(missionId)));
+
+        var rocket = service.GetById(rocketId)!;
+        Assert.Equal(RocketStatus.Available, rocket.Status);
+        Assert.Null(rocket.AssignedMissionId);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/StationAvailabilityServiceTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/StationAvailabilityServiceTests.cs
@@ -1,0 +1,138 @@
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class StationAvailabilityServiceTests
+{
+    [Fact]
+    public async Task IsRocketAvailable_returns_true_when_available()
+    {
+        var rocketService = new InMemoryRocketService();
+        var padService = new InMemoryLaunchPadService();
+        var crewService = new InMemoryCrewService();
+        var sut = new InMemoryStationAvailabilityService(rocketService, padService, crewService);
+
+        var rocketId = Guid.NewGuid();
+        await rocketService.CreateOrUpdateAsync(new Rocket
+        {
+            RocketId = rocketId,
+            RocketName = "Falcon",
+            Status = RocketStatus.Available
+        });
+
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        var available = await sut.IsRocketAvailableAsync(new RocketId(rocketId), window);
+
+        Assert.True(available);
+    }
+
+    [Fact]
+    public async Task IsRocketAvailable_returns_false_when_not_available()
+    {
+        var rocketService = new InMemoryRocketService();
+        var sut = new InMemoryStationAvailabilityService(rocketService, new InMemoryLaunchPadService(), new InMemoryCrewService());
+
+        var rocketId = Guid.NewGuid();
+        await rocketService.CreateOrUpdateAsync(new Rocket
+        {
+            RocketId = rocketId,
+            RocketName = "Falcon",
+            Status = RocketStatus.Assigned,
+            AssignedMissionId = Guid.NewGuid()
+        });
+
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        var available = await sut.IsRocketAvailableAsync(new RocketId(rocketId), window);
+
+        Assert.False(available);
+    }
+
+    [Fact]
+    public async Task IsLaunchPadAvailable_returns_true_when_no_overlap_and_not_under_maintenance()
+    {
+        var rocketService = new InMemoryRocketService();
+        var padService = new InMemoryLaunchPadService();
+        var crewService = new InMemoryCrewService();
+        var sut = new InMemoryStationAvailabilityService(rocketService, padService, crewService);
+
+        var padId = Guid.NewGuid();
+        await padService.CreateOrUpdateAsync(new LaunchPad
+        {
+            LaunchPadId = padId,
+            PadName = "Pad 1",
+            Status = LaunchPadStatus.Available,
+            SupportedRocketTypes = ["Falcon"]
+        });
+
+        var window = new LaunchWindow(DateTime.UtcNow.AddHours(1), DateTime.UtcNow.AddHours(2));
+        var available = await sut.IsLaunchPadAvailableAsync(new LaunchPadId(padId), window);
+
+        Assert.True(available);
+    }
+
+    [Fact]
+    public async Task IsLaunchPadAvailable_returns_false_when_overlap()
+    {
+        var padService = new InMemoryLaunchPadService();
+        var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), padService, new InMemoryCrewService());
+
+        var padId = Guid.NewGuid();
+        var window1 = new LaunchWindow(DateTime.UtcNow.AddHours(1), DateTime.UtcNow.AddHours(2));
+        await padService.CreateOrUpdateAsync(new LaunchPad
+        {
+            LaunchPadId = padId,
+            PadName = "Pad 2",
+            Status = LaunchPadStatus.Available,
+            OccupiedWindows = [
+                new ScheduledLaunchWindow
+                {
+                    MissionId = Guid.NewGuid(),
+                    Start = window1.Start,
+                    End = window1.End
+                }
+            ]
+        });
+
+        var checkWindow = new LaunchWindow(DateTime.UtcNow.AddHours(1.5), DateTime.UtcNow.AddHours(2.5));
+        var available = await sut.IsLaunchPadAvailableAsync(new LaunchPadId(padId), checkWindow);
+
+        Assert.False(available);
+    }
+
+    [Fact]
+    public async Task AreCrewMembersAvailable_returns_true_when_all_available()
+    {
+        var crewService = new InMemoryCrewService();
+        var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), new InMemoryLaunchPadService(), crewService);
+
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        await crewService.CreateOrUpdateAsync(new CrewMember { CrewMemberId = id1, Name = "A", Role = "Pilot", Status = CrewMemberStatus.Available });
+        await crewService.CreateOrUpdateAsync(new CrewMember { CrewMemberId = id2, Name = "B", Role = "Pilot", Status = CrewMemberStatus.Available });
+
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        var available = await sut.AreCrewMembersAvailableAsync(new[] { new CrewMemberId(id1), new CrewMemberId(id2) }, window);
+
+        Assert.True(available);
+    }
+
+    [Fact]
+    public async Task AreCrewMembersAvailable_returns_false_when_any_unavailable()
+    {
+        var crewService = new InMemoryCrewService();
+        var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), new InMemoryLaunchPadService(), crewService);
+
+        var id1 = Guid.NewGuid();
+        var id2 = Guid.NewGuid();
+        await crewService.CreateOrUpdateAsync(new CrewMember { CrewMemberId = id1, Name = "A", Role = "Pilot", Status = CrewMemberStatus.Available });
+        await crewService.CreateOrUpdateAsync(new CrewMember { CrewMemberId = id2, Name = "B", Role = "Pilot", Status = CrewMemberStatus.Assigned });
+
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        var available = await sut.AreCrewMembersAvailableAsync(new[] { new CrewMemberId(id1), new CrewMemberId(id2) }, window);
+
+        Assert.False(available);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit tests for InMemoryStationAvailabilityService

## Testing
- `dotnet test example/RocketLaunch.ReadModel.Tests/RocketLaunch.ReadModel.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686d1e25ad2483289224ce96d95cf761