### PR TITLE
Implement mission command handlers

### DIFF
--- a/example/RocketLaunch.Application/Command/Handler/AbortMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/AbortMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class AbortMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<AbortMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(AbortMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.Abort();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/LaunchMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/LaunchMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class LaunchMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<LaunchMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(LaunchMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.MarkLaunched();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/MarkMissionArrivedCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/MarkMissionArrivedCommandHandler.cs
@@ -1,0 +1,33 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class MarkMissionArrivedCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<MarkMissionArrivedCommand>(repository)
+{
+    public override async Task HandleCommandAsync(MarkMissionArrivedCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        var crew = command.CrewManifest.Select(c => (c.Name, c.Role));
+        var payload = command.PayloadManifest.Select(p => (p.Item, p.Mass));
+        mission.MarkArrived(command.ArrivalTime, command.VehicleType, crew, payload);
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/ScheduleMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/ScheduleMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class ScheduleMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<ScheduleMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(ScheduleMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.Schedule();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -38,6 +38,10 @@ namespace RocketLaunch.Application
                 () => new AssignLaunchPadCommandHandler(repository, _validator));
             _commandProcessor.RegisterHandlerFactory(
                 () => new AssignCrewCommandHandler(repository, _validator));
+            _commandProcessor.RegisterHandlerFactory(() => new ScheduleMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new LaunchMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new MarkMissionArrivedCommandHandler(repository));
         }
 
         public async Task<ICommandExecutionResult> ExecuteAsync<TCommand>(TCommand command)


### PR DESCRIPTION
## Summary
- implement handlers for AbortMission, LaunchMission, MarkMissionArrived and ScheduleMission
- register new handlers in `DomainEntry`

## Testing
- `dotnet build DDD.BuildingBlocks.sln`
- `dotnet test example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj --no-build --logger trx` *(fails: No test available)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c4271888328ac8bcd765a613553