### PR TITLE
Implement mission command handlers

### DIFF
--- a/example/RocketLaunch.Application.Tests/AbortMissionCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/AbortMissionCommandTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class AbortMissionCommandTests
+{
+    [Fact]
+    public async Task Handle_AbortMissionCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+        var store = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(store);
+
+        var registerHandler = new RegisterMissionCommandHandler(repository);
+        var registerCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Moon",
+            payloadDescription: "Rover",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+        await registerHandler.HandleCommandAsync(registerCommand);
+
+        var rocketHandler = new AssignRocketCommandHandler(repository, validator);
+        await rocketHandler.HandleCommandAsync(new AssignRocketCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var padHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        await padHandler.HandleCommandAsync(new AssignLaunchPadCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var scheduleHandler = new ScheduleMissionCommandHandler(repository);
+        await scheduleHandler.HandleCommandAsync(new ScheduleMissionCommand(registerCommand.MissionId));
+
+        var handler = new AbortMissionCommandHandler(repository);
+        await handler.HandleCommandAsync(new AbortMissionCommand(registerCommand.MissionId));
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerCommand.MissionId));
+        Debug.Assert(mission != null);
+        Assert.Equal(MissionStatus.Aborted, mission.Status);
+        Assert.Equal(4, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application.Tests/LaunchMissionCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/LaunchMissionCommandTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class LaunchMissionCommandTests
+{
+    [Fact]
+    public async Task Handle_LaunchMissionCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+        var store = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(store);
+
+        var registerHandler = new RegisterMissionCommandHandler(repository);
+        var registerCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Moon",
+            payloadDescription: "Rover",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+        await registerHandler.HandleCommandAsync(registerCommand);
+
+        var rocketHandler = new AssignRocketCommandHandler(repository, validator);
+        await rocketHandler.HandleCommandAsync(new AssignRocketCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var padHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        await padHandler.HandleCommandAsync(new AssignLaunchPadCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var scheduleHandler = new ScheduleMissionCommandHandler(repository);
+        await scheduleHandler.HandleCommandAsync(new ScheduleMissionCommand(registerCommand.MissionId));
+
+        var handler = new LaunchMissionCommandHandler(repository);
+        await handler.HandleCommandAsync(new LaunchMissionCommand(registerCommand.MissionId));
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerCommand.MissionId));
+        Debug.Assert(mission != null);
+        Assert.Equal(MissionStatus.Launched, mission.Status);
+        Assert.Equal(4, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application.Tests/MarkMissionArrivedCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/MarkMissionArrivedCommandTests.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class MarkMissionArrivedCommandTests
+{
+    [Fact]
+    public async Task Handle_MarkMissionArrivedCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+        var store = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(store);
+
+        var registerHandler = new RegisterMissionCommandHandler(repository);
+        var registerCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Moon",
+            payloadDescription: "Rover",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+        await registerHandler.HandleCommandAsync(registerCommand);
+
+        var rocketHandler = new AssignRocketCommandHandler(repository, validator);
+        await rocketHandler.HandleCommandAsync(new AssignRocketCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var padHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        await padHandler.HandleCommandAsync(new AssignLaunchPadCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var scheduleHandler = new ScheduleMissionCommandHandler(repository);
+        await scheduleHandler.HandleCommandAsync(new ScheduleMissionCommand(registerCommand.MissionId));
+
+        var launchHandler = new LaunchMissionCommandHandler(repository);
+        await launchHandler.HandleCommandAsync(new LaunchMissionCommand(registerCommand.MissionId));
+
+        var arrivalTime = DateTime.UtcNow;
+        var crew = new[] { new CrewManifestItemDto("Neil", "Commander") };
+        var payload = new[] { new PayloadManifestItemDto("Lander", 1000) };
+        var handler = new MarkMissionArrivedCommandHandler(repository);
+        await handler.HandleCommandAsync(new MarkMissionArrivedCommand(
+            registerCommand.MissionId,
+            arrivalTime,
+            "Saturn V",
+            crew,
+            payload
+        ));
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerCommand.MissionId));
+        Debug.Assert(mission != null);
+        Assert.Equal(MissionStatus.Arrived, mission.Status);
+        Assert.Equal(5, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj
+++ b/example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj
@@ -6,10 +6,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
       <PackageReference Include="xunit" Version="2.9.3" />
-    </ItemGroup>
+      <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+  </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\DDD.BuildingBlocks.DevelopmentPackage\DDD.BuildingBlocks.DevelopmentPackage.csproj" />

--- a/example/RocketLaunch.Application.Tests/ScheduleMissionCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/ScheduleMissionCommandTests.cs
@@ -1,0 +1,49 @@
+using System.Diagnostics;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using DDD.BuildingBlocks.DevelopmentPackage.Storage;
+using RocketLaunch.Application.Command;
+using RocketLaunch.Application.Command.Handler;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Application.Tests.Mocks;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.Application.Tests;
+
+public class ScheduleMissionCommandTests
+{
+    [Fact]
+    public async Task Handle_ScheduleMissionCommand()
+    {
+        var validator = new StubResourceAvailabilityService();
+        var eventStore = new PureInMemoryEventStorageProvider();
+        var repository = new EventSourcingRepository(eventStore);
+
+        var registerHandler = new RegisterMissionCommandHandler(repository);
+        var registerCommand = new RegisterMissionCommand(
+            missionId: Guid.NewGuid(),
+            missionName: "Apollo 11",
+            targetOrbit: "Moon",
+            payloadDescription: "Rover",
+            launchWindow: new LaunchWindowDto(DateTime.UtcNow, DateTime.UtcNow + TimeSpan.FromDays(6))
+        );
+        await registerHandler.HandleCommandAsync(registerCommand);
+
+        var rocketHandler = new AssignRocketCommandHandler(repository, validator);
+        await rocketHandler.HandleCommandAsync(new AssignRocketCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var padHandler = new AssignLaunchPadCommandHandler(repository, validator);
+        await padHandler.HandleCommandAsync(new AssignLaunchPadCommand(registerCommand.MissionId, Guid.NewGuid()));
+
+        var handler = new ScheduleMissionCommandHandler(repository);
+        await handler.HandleCommandAsync(new ScheduleMissionCommand(registerCommand.MissionId));
+
+        var mission = await repository.GetByIdAsync<Mission, MissionId>(new MissionId(registerCommand.MissionId));
+
+        Debug.Assert(mission != null);
+        Assert.Equal(MissionStatus.Scheduled, mission.Status);
+        Assert.Equal(3, mission.CurrentVersion);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/AbortMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/AbortMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class AbortMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<AbortMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(AbortMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.Abort();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/LaunchMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/LaunchMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class LaunchMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<LaunchMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(LaunchMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.MarkLaunched();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/MarkMissionArrivedCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/MarkMissionArrivedCommandHandler.cs
@@ -1,0 +1,33 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Application.Dto;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class MarkMissionArrivedCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<MarkMissionArrivedCommand>(repository)
+{
+    public override async Task HandleCommandAsync(MarkMissionArrivedCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        var crew = command.CrewManifest.Select(c => (c.Name, c.Role));
+        var payload = command.PayloadManifest.Select(p => (p.Item, p.Mass));
+        mission.MarkArrived(command.ArrivalTime, command.VehicleType, crew, payload);
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/Command/Handler/ScheduleMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Handler/ScheduleMissionCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class ScheduleMissionCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<ScheduleMissionCommand>(repository)
+{
+    public override async Task HandleCommandAsync(ScheduleMissionCommand command)
+    {
+        Mission mission;
+
+        try
+        {
+            mission = await AggregateSourcing.Source<Mission, MissionId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        mission.Schedule();
+
+        await AggregateRepository.SaveAsync(mission);
+    }
+}

--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -38,6 +38,10 @@ namespace RocketLaunch.Application
                 () => new AssignLaunchPadCommandHandler(repository, _validator));
             _commandProcessor.RegisterHandlerFactory(
                 () => new AssignCrewCommandHandler(repository, _validator));
+            _commandProcessor.RegisterHandlerFactory(() => new ScheduleMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new LaunchMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new MarkMissionArrivedCommandHandler(repository));
         }
 
         public async Task<ICommandExecutionResult> ExecuteAsync<TCommand>(TCommand command)


### PR DESCRIPTION
## Summary
- implement handlers for AbortMission, LaunchMission, MarkMissionArrived and ScheduleMission
- register new handlers in `DomainEntry`
- add tests for mission command handlers
- enable xUnit test runner

## Testing
- `dotnet build DDD.BuildingBlocks.sln`
- `dotnet test example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj --no-build --logger trx`

------
https://chatgpt.com/codex/tasks/task_e_686d2c4271888328ac8bcd765a613553