### PR TITLE
Add Swagger and JSON configuration

### DIFF
--- a/example/RocketLaunch.Api/Program.cs
+++ b/example/RocketLaunch.Api/Program.cs
@@ -8,6 +8,8 @@ using DDD.BuildingBlocks.DevelopmentPackage.Storage;
 using DDD.BuildingBlocks.DI.Extensions;
 using DDD.BuildingBlocks.Hosting.Background;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using RocketLaunch.Api;
 using RocketLaunch.Application;
 using RocketLaunch.Api.Handler;
 using RocketLaunch.Domain.Service;
@@ -15,12 +17,21 @@ using RocketLaunch.ReadModel.Core.Builder;
 using RocketLaunch.ReadModel.Core.Service;
 using RocketLaunch.ReadModel.InMemory.Service;
 
-var workerId = "rocket-launch-worker";
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Configuration.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+var rocketOptions = builder.Configuration.GetSection("RocketLaunch").Get<RocketLaunchApiOptions>() ?? new RocketLaunchApiOptions();
+var workerId = rocketOptions.WorkerId;
 
 builder.Logging.AddConsole();
 
 var services = builder.Services;
+services.AddEndpointsApiExplorer();
+services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Rocket Launch API", Version = "v1" });
+});
+services.Configure<RocketLaunchApiOptions>(builder.Configuration.GetSection("RocketLaunch"));
 
 // Event publishing infrastructure
 services.AddSingleton<EventPublishingTable>(x =>
@@ -33,7 +44,7 @@ services.AddSingleton<EventPublishingTable>(x =>
 
 services.AddSingleton<DomainEventNotifier>(sp =>
 {
-    var notifier = new DomainEventNotifier("RocketLaunch.ReadModel.Core");
+    var notifier = new DomainEventNotifier(rocketOptions.ReadModelAssemblyName);
     notifier.SetDependencyResolver(new ServiceLocator(sp));
     return notifier;
 });
@@ -48,7 +59,8 @@ services.AddSingleton<DomainEventProjectionDispatcher>(sp =>
         workerId,
         sp.GetService<ILoggerFactory>()));
 
-services.Configure<TimedHostedServiceOptions>(o => o.GlobalTriggerTimeoutInMilliseconds = 1000);
+services.Configure<TimedHostedServiceOptions>(o =>
+    o.GlobalTriggerTimeoutInMilliseconds = rocketOptions.GlobalTriggerTimeoutInMilliseconds);
 
 services.AddHostedService(sp =>
     new TimedHostedService<DomainEventProjectionDispatcher>(
@@ -60,8 +72,13 @@ services.AddHostedService(sp =>
 services.AddSingleton<IEventStorageProvider>(sp =>
     new PureInMemoryEventStorageProvider(sp.GetRequiredService<EventPublishingTable>()));
 
-var snapshotPath = Path.Combine(AppContext.BaseDirectory, "mission.snapshots.dump");
-services.AddSingleton<ISnapshotStorageProvider>(sp => new InMemorySnapshotStorageProvider(5, snapshotPath));
+var snapshotPath = rocketOptions.SnapshotPath;
+if (!Path.IsPathRooted(snapshotPath))
+{
+    snapshotPath = Path.Combine(AppContext.BaseDirectory, snapshotPath);
+}
+services.AddSingleton<ISnapshotStorageProvider>(sp =>
+    new InMemorySnapshotStorageProvider(rocketOptions.SnapshotThreshold, snapshotPath));
 
 services.AddSingleton<IEventSourcingRepository>(sp =>
     new EventSourcingRepository(
@@ -88,6 +105,9 @@ services.AddSingleton<IDomainEntry>(sp => new DomainEntry(
     sp.GetRequiredService<IResourceAvailabilityService>()));
 
 var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 // Minimal API endpoints
 app.MapMissionRoutes();

--- a/example/RocketLaunch.Api/RocketLaunch.Api.csproj
+++ b/example/RocketLaunch.Api/RocketLaunch.Api.csproj
@@ -5,11 +5,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <ProjectReference Include="..\RocketLaunch.Application\RocketLaunch.Application.csproj" />
     <ProjectReference Include="..\RocketLaunch.ReadModel.InMemory\RocketLaunch.ReadModel.InMemory.csproj" />
     <ProjectReference Include="..\..\src\DDD.BuildingBlocks.Core\DDD.BuildingBlocks.Core.csproj" />
     <ProjectReference Include="..\..\src\DDD.BuildingBlocks.DevelopmentPackage\DDD.BuildingBlocks.DevelopmentPackage.csproj" />
     <ProjectReference Include="..\..\src\DDD.BuildingBlocks.DI.Extensions\DDD.BuildingBlocks.DI.Extensions.csproj" />
     <ProjectReference Include="..\..\src\DDD.BuildingBlocks.Hosting.Background\DDD.BuildingBlocks.Hosting.Background.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/example/RocketLaunch.Api/RocketLaunchApiOptions.cs
+++ b/example/RocketLaunch.Api/RocketLaunchApiOptions.cs
@@ -1,0 +1,13 @@
+using System;
+using System.IO;
+
+namespace RocketLaunch.Api;
+
+public sealed class RocketLaunchApiOptions
+{
+    public string WorkerId { get; set; } = "rocket-launch-worker";
+    public string ReadModelAssemblyName { get; set; } = "RocketLaunch.ReadModel.Core";
+    public string SnapshotPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "mission.snapshots.dump");
+    public int SnapshotThreshold { get; set; } = 5;
+    public int GlobalTriggerTimeoutInMilliseconds { get; set; } = 1000;
+}

--- a/example/RocketLaunch.Api/appsettings.json
+++ b/example/RocketLaunch.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "RocketLaunch": {
+    "WorkerId": "rocket-launch-worker",
+    "ReadModelAssemblyName": "RocketLaunch.ReadModel.Core",
+    "SnapshotPath": "mission.snapshots.dump",
+    "SnapshotThreshold": 5,
+    "GlobalTriggerTimeoutInMilliseconds": 1000
+  }
+}


### PR DESCRIPTION
## Summary
- enable Swagger UI and add endpoints for API testing
- support RocketLaunchApiOptions bound from appsettings.json
- bind TimedHostedServiceOptions and snapshot settings from configuration
- include Swashbuckle.AspNetCore package and appsettings.json in build output

## Testing
- `dotnet build DDD.BuildingBlocks.sln -v minimal`
- `dotnet test DDD.BuildingBlocks.sln -v minimal` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_686d4b99b02883288788a5f9711780ca