### PR TITLE
Add CrewMember commands/handlers

### DIFF
--- a/example/RocketLaunch.Application/Command/CrewMember/AssignCrewMemberCommand.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/AssignCrewMemberCommand.cs
@@ -1,0 +1,21 @@
+namespace RocketLaunch.Application.Command;
+
+/// <summary>
+/// Command to mark a crew member as assigned.
+///
+/// Preconditions:
+/// - Crew member must be in Available status.
+///
+/// Side Effects:
+/// - Emits CrewMemberAssigned domain event.
+/// </summary>
+public class AssignCrewMemberCommand : DDD.BuildingBlocks.Core.Commanding.Command
+{
+    public Guid CrewMemberId { get; }
+
+    public AssignCrewMemberCommand(Guid crewMemberId)
+        : base(crewMemberId.ToString(), -1)
+    {
+        CrewMemberId = crewMemberId;
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/Handler/AssignCrewMemberCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/Handler/AssignCrewMemberCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class AssignCrewMemberCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<AssignCrewMemberCommand>(repository)
+{
+    public override async Task HandleCommandAsync(AssignCrewMemberCommand command)
+    {
+        CrewMember crewMember;
+
+        try
+        {
+            crewMember = await AggregateSourcing.Source<CrewMember, CrewMemberId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        crewMember.Assign();
+
+        await AggregateRepository.SaveAsync(crewMember);
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/Handler/RegisterCrewMemberCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/Handler/RegisterCrewMemberCommandHandler.cs
@@ -1,0 +1,35 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class RegisterCrewMemberCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<RegisterCrewMemberCommand>(repository)
+{
+    public override async Task HandleCommandAsync(RegisterCrewMemberCommand command)
+    {
+        CrewMember crewMember;
+
+        try
+        {
+            crewMember = await AggregateSourcing.Source<CrewMember, CrewMemberId>(
+                command,
+                new CrewMemberId(command.CrewMemberId),
+                command.Name,
+                command.Role,
+                command.Certifications
+            );
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        await AggregateRepository.SaveAsync(crewMember);
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/Handler/ReleaseCrewMemberCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/Handler/ReleaseCrewMemberCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class ReleaseCrewMemberCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<ReleaseCrewMemberCommand>(repository)
+{
+    public override async Task HandleCommandAsync(ReleaseCrewMemberCommand command)
+    {
+        CrewMember crewMember;
+
+        try
+        {
+            crewMember = await AggregateSourcing.Source<CrewMember, CrewMemberId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        crewMember.Release();
+
+        await AggregateRepository.SaveAsync(crewMember);
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/Handler/SetCrewMemberCertificationsCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/Handler/SetCrewMemberCertificationsCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class SetCrewMemberCertificationsCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<SetCrewMemberCertificationsCommand>(repository)
+{
+    public override async Task HandleCommandAsync(SetCrewMemberCertificationsCommand command)
+    {
+        CrewMember crewMember;
+
+        try
+        {
+            crewMember = await AggregateSourcing.Source<CrewMember, CrewMemberId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        crewMember.SetCertifications(command.Certifications);
+
+        await AggregateRepository.SaveAsync(crewMember);
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/Handler/SetCrewMemberStatusCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/Handler/SetCrewMemberStatusCommandHandler.cs
@@ -1,0 +1,30 @@
+using DDD.BuildingBlocks.Core.Commanding;
+using DDD.BuildingBlocks.Core.Exception;
+using DDD.BuildingBlocks.Core.Exception.Constants;
+using DDD.BuildingBlocks.Core.Persistence.Repository;
+using RocketLaunch.Domain.Model;
+using RocketLaunch.SharedKernel.ValueObjects;
+
+namespace RocketLaunch.Application.Command.Handler;
+
+public class SetCrewMemberStatusCommandHandler(IEventSourcingRepository repository)
+    : CommandHandler<SetCrewMemberStatusCommand>(repository)
+{
+    public override async Task HandleCommandAsync(SetCrewMemberStatusCommand command)
+    {
+        CrewMember crewMember;
+
+        try
+        {
+            crewMember = await AggregateSourcing.Source<CrewMember, CrewMemberId>(command);
+        }
+        catch (Exception e)
+        {
+            throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
+        }
+
+        crewMember.SetStatus(command.Status);
+
+        await AggregateRepository.SaveAsync(crewMember);
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/RegisterCrewMemberCommand.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/RegisterCrewMemberCommand.cs
@@ -1,0 +1,36 @@
+namespace RocketLaunch.Application.Command;
+
+using DDD.BuildingBlocks.Core.Commanding;
+using RocketLaunch.SharedKernel.Enums;
+
+/// <summary>
+/// Command to register a new crew member.
+///
+/// Preconditions:
+/// - CrewMemberId must be unique.
+///
+/// Side Effects:
+/// - Emits CrewMemberAssigned event with Available status (implicit from creation).
+/// </summary>
+public class RegisterCrewMemberCommand : Command
+{
+    public Guid CrewMemberId { get; }
+    public string Name { get; }
+    public CrewRole Role { get; }
+    public IReadOnlyCollection<string> Certifications { get; }
+
+    public RegisterCrewMemberCommand(
+        Guid crewMemberId,
+        string name,
+        CrewRole role,
+        IEnumerable<string> certifications)
+        : base(crewMemberId.ToString(), -1)
+    {
+        CrewMemberId  = crewMemberId;
+        Name          = name ?? throw new ArgumentNullException(nameof(name));
+        Role          = role;
+        Certifications = new List<string>(certifications ?? throw new ArgumentNullException(nameof(certifications))).AsReadOnly();
+
+        Mode = AggregateSourcingMode.Create;
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/ReleaseCrewMemberCommand.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/ReleaseCrewMemberCommand.cs
@@ -1,0 +1,18 @@
+namespace RocketLaunch.Application.Command;
+
+/// <summary>
+/// Command to release a crew member from assignment.
+///
+/// Side Effects:
+/// - Emits CrewMemberReleased domain event.
+/// </summary>
+public class ReleaseCrewMemberCommand : DDD.BuildingBlocks.Core.Commanding.Command
+{
+    public Guid CrewMemberId { get; }
+
+    public ReleaseCrewMemberCommand(Guid crewMemberId)
+        : base(crewMemberId.ToString(), -1)
+    {
+        CrewMemberId = crewMemberId;
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/SetCrewMemberCertificationsCommand.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/SetCrewMemberCertificationsCommand.cs
@@ -1,0 +1,19 @@
+namespace RocketLaunch.Application.Command;
+
+using DDD.BuildingBlocks.Core.Commanding;
+
+/// <summary>
+/// Command to update the certifications of a crew member.
+/// </summary>
+public class SetCrewMemberCertificationsCommand : Command
+{
+    public Guid CrewMemberId { get; }
+    public IReadOnlyCollection<string> Certifications { get; }
+
+    public SetCrewMemberCertificationsCommand(Guid crewMemberId, IEnumerable<string> certifications)
+        : base(crewMemberId.ToString(), -1)
+    {
+        CrewMemberId   = crewMemberId;
+        Certifications = new List<string>(certifications ?? throw new ArgumentNullException(nameof(certifications))).AsReadOnly();
+    }
+}

--- a/example/RocketLaunch.Application/Command/CrewMember/SetCrewMemberStatusCommand.cs
+++ b/example/RocketLaunch.Application/Command/CrewMember/SetCrewMemberStatusCommand.cs
@@ -1,0 +1,20 @@
+namespace RocketLaunch.Application.Command;
+
+using DDD.BuildingBlocks.Core.Commanding;
+using RocketLaunch.SharedKernel.Enums;
+
+/// <summary>
+/// Command to set the status of a crew member.
+/// </summary>
+public class SetCrewMemberStatusCommand : Command
+{
+    public Guid CrewMemberId { get; }
+    public CrewMemberStatus Status { get; }
+
+    public SetCrewMemberStatusCommand(Guid crewMemberId, CrewMemberStatus status)
+        : base(crewMemberId.ToString(), -1)
+    {
+        CrewMemberId = crewMemberId;
+        Status       = status;
+    }
+}

--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -42,6 +42,12 @@ namespace RocketLaunch.Application
             _commandProcessor.RegisterHandlerFactory(() => new LaunchMissionCommandHandler(repository));
             _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository));
             _commandProcessor.RegisterHandlerFactory(() => new MarkMissionArrivedCommandHandler(repository));
+
+            _commandProcessor.RegisterHandlerFactory(() => new RegisterCrewMemberCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new AssignCrewMemberCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new ReleaseCrewMemberCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new SetCrewMemberCertificationsCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new SetCrewMemberStatusCommandHandler(repository));
         }
 
         public async Task<ICommandExecutionResult> ExecuteAsync<TCommand>(TCommand command)

--- a/example/RocketLaunch.Domain/Model/CrewMember.cs
+++ b/example/RocketLaunch.Domain/Model/CrewMember.cs
@@ -21,7 +21,7 @@ public class CrewMember : AggregateRoot<CrewMemberId>
     }
 
     // For rehydration
-    private CrewMember() : base(default!) { }
+    public CrewMember() : base(default!) { }
 
     public string Name { get; private set; } = null!;
     public CrewRole Role { get; private set; }


### PR DESCRIPTION
## Summary
- add commands for CrewMember aggregate
- implement command handlers for CrewMember
- register new handlers in DomainEntry
- expose parameterless constructor on CrewMember for rehydration

## Testing
- `dotnet build --no-restore`
- `dotnet test example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d545d53ec8328945854e75105801b