### PR TITLE
Add CrewAssignment service and update crew handling

### DIFF
--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -11,12 +11,14 @@ namespace RocketLaunch.Application
     {
         private readonly ICommandProcessor _commandProcessor;
         private readonly IResourceAvailabilityService _validator;
+        private readonly CrewAssignment _crewAssignment;
 
         public DomainEntry(
             ICommandProcessor commandProcessor, IEventSourcingRepository repository, IResourceAvailabilityService validator)
         {
             _commandProcessor = commandProcessor;
             _validator = validator;
+            _crewAssignment = new CrewAssignment(validator);
 
             RegisterCommandsForManagementDomain(repository);
 
@@ -38,7 +40,7 @@ namespace RocketLaunch.Application
             _commandProcessor.RegisterHandlerFactory(
                 () => new AssignLaunchPadCommandHandler(repository, _validator));
             _commandProcessor.RegisterHandlerFactory(
-                () => new AssignCrewCommandHandler(repository, _validator));
+                () => new AssignCrewCommandHandler(repository, _crewAssignment));
             _commandProcessor.RegisterHandlerFactory(() => new ScheduleMissionCommandHandler(repository));
             _commandProcessor.RegisterHandlerFactory(() => new LaunchMissionCommandHandler(repository));
             _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository));

--- a/example/RocketLaunch.Domain/Service/CrewAssignment.cs
+++ b/example/RocketLaunch.Domain/Service/CrewAssignment.cs
@@ -1,0 +1,23 @@
+namespace RocketLaunch.Domain.Service;
+
+public class CrewAssignment
+{
+    private readonly IResourceAvailabilityService _validator;
+
+    public CrewAssignment(IResourceAvailabilityService validator)
+    {
+        _validator = validator;
+    }
+
+    public async Task AssignAsync(Model.Mission mission, IEnumerable<Model.CrewMember> crewMembers)
+    {
+        if (mission == null) throw new ArgumentNullException(nameof(mission));
+        if (crewMembers == null) throw new ArgumentNullException(nameof(crewMembers));
+        var list = crewMembers.ToList();
+        await mission.AssignCrewAsync(list.Select(cm => cm.Id), _validator);
+        foreach (var member in list)
+        {
+            member.Assign();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CrewAssignment` service in RocketLaunch.Domain
- inject and utilize this service in `AssignCrewCommandHandler`
- wire new service into `DomainEntry`
- register crew members within tests and verify crew assignments

## Testing
- `dotnet test --no-build` *(fails: Docker.DotNet unable to connect)*

------
https://chatgpt.com/codex/tasks/task_e_686fee7f3b2483288894844621c58860