### PR TITLE
Add crew unassignment service

### DIFF
--- a/example/RocketLaunch.Application.Tests/Mission/AbortMissionCommandTests.cs
+++ b/example/RocketLaunch.Application.Tests/Mission/AbortMissionCommandTests.cs
@@ -5,6 +5,9 @@ using RocketLaunch.Application.Command;
 using RocketLaunch.Application.Command.Mission;
 using RocketLaunch.Application.Command.Mission.Handler;
 using RocketLaunch.Application.Dto;
+using RocketLaunch.Domain.Service;
+using RocketLaunch.Application.Command.CrewMember;
+using RocketLaunch.Application.Command.CrewMember.Handler;
 using RocketLaunch.Application.Tests.Mocks;
 using RocketLaunch.SharedKernel.Enums;
 using RocketLaunch.SharedKernel.ValueObjects;
@@ -37,15 +40,33 @@ public class AbortMissionCommandTests
         var padHandler = new AssignLaunchPadCommandHandler(repository, validator);
         await padHandler.HandleCommandAsync(new AssignLaunchPadCommand(registerCommand.MissionId, Guid.NewGuid()));
 
+        var crewAssignment = new CrewAssignment(validator);
+        var assignCrewHandler = new AssignCrewCommandHandler(repository, crewAssignment);
+        var crewIds = new[] { Guid.NewGuid(), Guid.NewGuid() };
+        var registerCrewHandler = new RegisterCrewMemberCommandHandler(repository);
+        foreach (var id in crewIds)
+        {
+            await registerCrewHandler.HandleCommandAsync(new RegisterCrewMemberCommand(id, $"Member-{id}", CrewRole.Commander, []));
+        }
+        await assignCrewHandler.HandleCommandAsync(new AssignCrewCommand(registerCommand.MissionId, crewIds));
+
         var scheduleHandler = new ScheduleMissionCommandHandler(repository);
         await scheduleHandler.HandleCommandAsync(new ScheduleMissionCommand(registerCommand.MissionId));
 
-        var handler = new AbortMissionCommandHandler(repository);
+        var unassignment = new CrewUnassignment();
+        var handler = new AbortMissionCommandHandler(repository, unassignment);
         await handler.HandleCommandAsync(new AbortMissionCommand(registerCommand.MissionId));
 
         var mission = await repository.GetByIdAsync<Domain.Model.Mission, MissionId>(new MissionId(registerCommand.MissionId));
         Debug.Assert(mission != null);
         Assert.Equal(MissionStatus.Aborted, mission.Status);
-        Assert.Equal(4, mission.CurrentVersion);
+        Assert.Equal(5, mission.CurrentVersion);
+
+        foreach (var id in crewIds)
+        {
+            var crewMember = await repository.GetByIdAsync<Domain.Model.CrewMember, CrewMemberId>(new CrewMemberId(id));
+            Debug.Assert(crewMember != null);
+            Assert.Equal(CrewMemberStatus.Available, crewMember.Status);
+        }
     }
 }

--- a/example/RocketLaunch.Application.Tests/Mission/CommandHandlerRuleTests.cs
+++ b/example/RocketLaunch.Application.Tests/Mission/CommandHandlerRuleTests.cs
@@ -151,7 +151,8 @@ public class CommandHandlerRuleTests
         var launchHandler = new LaunchMissionCommandHandler(repo);
         await launchHandler.HandleCommandAsync(new LaunchMissionCommand(missionId));
 
-        var handler = new AbortMissionCommandHandler(repo);
+        var unassignment = new CrewUnassignment();
+        var handler = new AbortMissionCommandHandler(repo, unassignment);
         var command = new AbortMissionCommand(missionId);
 
         await Assert.ThrowsAsync<DDD.BuildingBlocks.Core.Exception.AggregateException>(() => handler.HandleCommandAsync(command));

--- a/example/RocketLaunch.Application/Command/Mission/Handler/AbortMissionCommandHandler.cs
+++ b/example/RocketLaunch.Application/Command/Mission/Handler/AbortMissionCommandHandler.cs
@@ -2,13 +2,17 @@ using DDD.BuildingBlocks.Core.Commanding;
 using DDD.BuildingBlocks.Core.Exception;
 using DDD.BuildingBlocks.Core.Exception.Constants;
 using DDD.BuildingBlocks.Core.Persistence.Repository;
+using System;
 using RocketLaunch.SharedKernel.ValueObjects;
+using RocketLaunch.Application.Command.CrewMember;
+using RocketLaunch.Domain.Service;
 
 namespace RocketLaunch.Application.Command.Mission.Handler;
 
-public class AbortMissionCommandHandler(IEventSourcingRepository repository)
+public class AbortMissionCommandHandler(IEventSourcingRepository repository, CrewUnassignment crewUnassignment)
     : CommandHandler<AbortMissionCommand>(repository)
 {
+    private readonly CrewUnassignment _crewUnassignment = crewUnassignment;
     public override async Task HandleCommandAsync(AbortMissionCommand command)
     {
         Domain.Model.Mission mission;
@@ -22,8 +26,20 @@ public class AbortMissionCommandHandler(IEventSourcingRepository repository)
             throw new ApplicationProcessingException(HandlerErrors.ApplicationProcessingError, e);
         }
 
-        mission.Abort();
+        var crewMemberAggregates = new List<Domain.Model.CrewMember>();
+        foreach (var relation in mission.Crew)
+        {
+            var crewCmd = new ReleaseCrewMemberCommand(Guid.Parse(relation.AggregateId));
+            var member = await AggregateSourcing.Source<Domain.Model.CrewMember, CrewMemberId>(crewCmd);
+            crewMemberAggregates.Add(member);
+        }
+
+        _crewUnassignment.Unassign(mission, crewMemberAggregates);
 
         await AggregateRepository.SaveAsync(mission);
+        foreach (var crewMember in crewMemberAggregates)
+        {
+            await AggregateRepository.SaveAsync(crewMember);
+        }
     }
 }

--- a/example/RocketLaunch.Application/DomainEntry.cs
+++ b/example/RocketLaunch.Application/DomainEntry.cs
@@ -12,6 +12,7 @@ namespace RocketLaunch.Application
         private readonly ICommandProcessor _commandProcessor;
         private readonly IResourceAvailabilityService _validator;
         private readonly CrewAssignment _crewAssignment;
+        private readonly CrewUnassignment _crewUnassignment;
 
         public DomainEntry(
             ICommandProcessor commandProcessor, IEventSourcingRepository repository, IResourceAvailabilityService validator)
@@ -19,6 +20,7 @@ namespace RocketLaunch.Application
             _commandProcessor = commandProcessor;
             _validator = validator;
             _crewAssignment = new CrewAssignment(validator);
+            _crewUnassignment = new CrewUnassignment();
 
             RegisterCommandsForManagementDomain(repository);
 
@@ -43,7 +45,7 @@ namespace RocketLaunch.Application
                 () => new AssignCrewCommandHandler(repository, _crewAssignment));
             _commandProcessor.RegisterHandlerFactory(() => new ScheduleMissionCommandHandler(repository));
             _commandProcessor.RegisterHandlerFactory(() => new LaunchMissionCommandHandler(repository));
-            _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository));
+            _commandProcessor.RegisterHandlerFactory(() => new AbortMissionCommandHandler(repository, _crewUnassignment));
             _commandProcessor.RegisterHandlerFactory(() => new MarkMissionArrivedCommandHandler(repository));
 
             _commandProcessor.RegisterHandlerFactory(() => new RegisterCrewMemberCommandHandler(repository));

--- a/example/RocketLaunch.Domain/Service/CrewUnassignment.cs
+++ b/example/RocketLaunch.Domain/Service/CrewUnassignment.cs
@@ -1,0 +1,16 @@
+namespace RocketLaunch.Domain.Service;
+
+public class CrewUnassignment
+{
+    public void Unassign(Model.Mission mission, IEnumerable<Model.CrewMember> crewMembers)
+    {
+        if (mission == null) throw new ArgumentNullException(nameof(mission));
+        if (crewMembers == null) throw new ArgumentNullException(nameof(crewMembers));
+
+        mission.Abort();
+        foreach (var member in crewMembers)
+        {
+            member.Release();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `CrewUnassignment` domain service for aborting missions
- update AbortMission handler to release crew members
- wire up handler with unassignment service
- expand abort mission tests to verify crew members are released
- fix CommandHandlerRule test to pass new dependency

## Testing
- `dotnet test` *(fails: NETSDK1045 - .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_686fec3d9d608328898311cb78df834c