### PR TITLE
Implement Mission and CrewMember read models

### DIFF
--- a/example/RocketLaunch.Api/Program.cs
+++ b/example/RocketLaunch.Api/Program.cs
@@ -94,6 +94,7 @@ services.AddSingleton<IEventSourcingRepository>(sp =>
 services.AddSingleton<ICommandProcessor, DefaultCommandProcessor>();
 
 // Read model services and validators
+services.AddSingleton<IMissionService, InMemoryMissionService>();
 services.AddSingleton<IRocketService, InMemoryRocketService>();
 services.AddSingleton<ILaunchPadService, InMemoryLaunchPadService>();
 services.AddSingleton<ICrewMemberService, InMemoryCrewService>();
@@ -103,6 +104,7 @@ services.AddSingleton<IResourceAvailabilityService, InMemoryStationAvailabilityS
 services.AddTransient<RocketProjector>();
 services.AddTransient<LaunchPadProjector>();
 services.AddTransient<CrewMemberProjector>();
+services.AddTransient<MissionProjector>();
 
 // Domain entry
 services.AddSingleton<IDomainEntry>(sp => new DomainEntry(

--- a/example/RocketLaunch.ReadModel.Core/Model/Mission.cs
+++ b/example/RocketLaunch.ReadModel.Core/Model/Mission.cs
@@ -1,0 +1,19 @@
+using RocketLaunch.SharedKernel.Enums;
+
+namespace RocketLaunch.ReadModel.Core.Model;
+
+public class Mission
+{
+    public Guid MissionId { get; set; }
+    public string Name { get; set; } = default!;
+    public string TargetOrbit { get; set; } = default!;
+    public string Payload { get; set; } = default!;
+    public DateTime LaunchWindowStart { get; set; }
+    public DateTime LaunchWindowEnd { get; set; }
+
+    public MissionStatus Status { get; set; } = MissionStatus.Planned;
+
+    public Guid? AssignedRocketId { get; set; }
+    public Guid? AssignedPadId { get; set; }
+    public List<Guid> CrewMemberIds { get; set; } = new();
+}

--- a/example/RocketLaunch.ReadModel.Core/Projector/Mission/MissionProjector.cs
+++ b/example/RocketLaunch.ReadModel.Core/Projector/Mission/MissionProjector.cs
@@ -1,0 +1,139 @@
+using DDD.BuildingBlocks.Core.Event;
+using Microsoft.Extensions.Logging;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.Core.Service;
+using RocketLaunch.SharedKernel.Events.Mission;
+
+namespace RocketLaunch.ReadModel.Core.Projector.Mission;
+
+public class MissionProjector(IMissionService missionService, ILogger<MissionProjector> logger)
+    :
+        ISubscribe<MissionCreated>,
+        ISubscribe<RocketAssigned>,
+        ISubscribe<LaunchPadAssigned>,
+        ISubscribe<CrewAssigned>,
+        ISubscribe<MissionScheduled>,
+        ISubscribe<MissionAborted>,
+        ISubscribe<MissionLaunched>,
+        ISubscribe<MissionArrivedAtLunarOrbit>
+{
+    private readonly IMissionService _missionService = missionService ?? throw new ArgumentNullException(nameof(missionService));
+    private readonly ILogger<MissionProjector> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+    public async Task WhenAsync(MissionCreated @event)
+    {
+        var mission = new Model.Mission
+        {
+            MissionId = @event.MissionId.Value,
+            Name = @event.Name.Value,
+            TargetOrbit = @event.TargetOrbit.Value,
+            Payload = @event.Payload.Value,
+            LaunchWindowStart = @event.LaunchWindow.Start,
+            LaunchWindowEnd = @event.LaunchWindow.End,
+            Status = SharedKernel.Enums.MissionStatus.Planned
+        };
+
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(RocketAssigned @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for RocketAssigned", @event.MissionId);
+            return;
+        }
+
+        mission.AssignedRocketId = @event.RocketId.Value;
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(LaunchPadAssigned @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for LaunchPadAssigned", @event.MissionId);
+            return;
+        }
+
+        mission.AssignedPadId = @event.PadId.Value;
+        mission.LaunchWindowStart = @event.LaunchWindow.Start;
+        mission.LaunchWindowEnd = @event.LaunchWindow.End;
+
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(CrewAssigned @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for CrewAssigned", @event.MissionId);
+            return;
+        }
+
+        foreach (var crew in @event.Crew)
+        {
+            if (!mission.CrewMemberIds.Contains(crew.Value))
+            {
+                mission.CrewMemberIds.Add(crew.Value);
+            }
+        }
+
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(MissionScheduled @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for MissionScheduled", @event.MissionId);
+            return;
+        }
+
+        mission.Status = SharedKernel.Enums.MissionStatus.Scheduled;
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(MissionAborted @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for MissionAborted", @event.MissionId);
+            return;
+        }
+
+        mission.Status = SharedKernel.Enums.MissionStatus.Aborted;
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(MissionLaunched @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for MissionLaunched", @event.MissionId);
+            return;
+        }
+
+        mission.Status = SharedKernel.Enums.MissionStatus.Launched;
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+
+    public async Task WhenAsync(MissionArrivedAtLunarOrbit @event)
+    {
+        var mission = _missionService.GetById(@event.MissionId.Value);
+        if (mission == null)
+        {
+            _logger.LogWarning("Mission {MissionId} not found for MissionArrivedAtLunarOrbit", @event.MissionId);
+            return;
+        }
+
+        mission.Status = SharedKernel.Enums.MissionStatus.Arrived;
+        await _missionService.CreateOrUpdateAsync(mission);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
@@ -1,0 +1,9 @@
+using RocketLaunch.ReadModel.Core.Model;
+
+namespace RocketLaunch.ReadModel.Core.Service;
+
+public interface IMissionService
+{
+    Mission? GetById(Guid missionId);
+    Task CreateOrUpdateAsync(Mission mission);
+}

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.Core.Service;
+
+namespace RocketLaunch.ReadModel.InMemory.Service;
+
+public class InMemoryMissionService : IMissionService
+{
+    private readonly ConcurrentDictionary<Guid, Mission> _missions = new();
+
+    public Mission? GetById(Guid missionId)
+    {
+        _missions.TryGetValue(missionId, out var mission);
+        return mission;
+    }
+
+    public Task CreateOrUpdateAsync(Mission mission)
+    {
+        _missions[mission.MissionId] = mission;
+        return Task.CompletedTask;
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.Core.Projector.CrewMember;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.Events.CrewMember;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class CrewMemberProjectorTests
+{
+    [Fact]
+    public async Task CrewMemberRegistered_creates_member()
+    {
+        var missionService = new InMemoryMissionService();
+        var service = new InMemoryCrewService(missionService);
+        var projector = new CrewMemberProjector(service, NullLogger<CrewMemberProjector>.Instance);
+
+        var memberId = Guid.NewGuid();
+        await projector.WhenAsync(new CrewMemberRegistered(new CrewMemberId(memberId), "Alice", SharedKernel.Enums.CrewRole.Commander, ["Flight"]));
+
+        var member = service.GetById(memberId)!;
+        Assert.Equal("Alice", member.Name);
+        Assert.Equal(CrewMemberStatus.Available, member.Status);
+    }
+
+    [Fact]
+    public async Task CrewMemberAssigned_sets_status_assigned()
+    {
+        var missionService = new InMemoryMissionService();
+        var service = new InMemoryCrewService(missionService);
+        var projector = new CrewMemberProjector(service, NullLogger<CrewMemberProjector>.Instance);
+
+        var memberId = Guid.NewGuid();
+        await service.CreateOrUpdateAsync(new CrewMember { CrewMemberId = memberId, Name = "Bob", Role = "Pilot", Status = CrewMemberStatus.Available });
+
+        await projector.WhenAsync(new CrewMemberAssigned(new CrewMemberId(memberId)));
+
+        var member = service.GetById(memberId)!;
+        Assert.Equal(CrewMemberStatus.Assigned, member.Status);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/MissionProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/MissionProjectorTests.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using RocketLaunch.ReadModel.Core.Projector.Mission;
+using RocketLaunch.ReadModel.InMemory.Service;
+using RocketLaunch.SharedKernel.Events.Mission;
+using RocketLaunch.SharedKernel.Enums;
+using RocketLaunch.SharedKernel.ValueObjects;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class MissionProjectorTests
+{
+    [Fact]
+    public async Task MissionCreated_creates_mission()
+    {
+        var service = new InMemoryMissionService();
+        var projector = new MissionProjector(service, NullLogger<MissionProjector>.Instance);
+
+        var missionId = Guid.NewGuid();
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        await projector.WhenAsync(new MissionCreated(new MissionId(missionId), new MissionName("Test"), new TargetOrbit("LEO"), new PayloadDescription("Sat"), window));
+
+        var mission = service.GetById(missionId)!;
+        Assert.Equal("Test", mission.Name);
+        Assert.Equal(MissionStatus.Planned, mission.Status);
+        Assert.Equal(window.Start, mission.LaunchWindowStart);
+    }
+
+    [Fact]
+    public async Task CrewAssigned_adds_members()
+    {
+        var service = new InMemoryMissionService();
+        var projector = new MissionProjector(service, NullLogger<MissionProjector>.Instance);
+        var missionId = Guid.NewGuid();
+        var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
+        await projector.WhenAsync(new MissionCreated(new MissionId(missionId), new MissionName("Test"), new TargetOrbit("LEO"), new PayloadDescription("Sat"), window));
+
+        var crewIds = new[] { new CrewMemberId(Guid.NewGuid()), new CrewMemberId(Guid.NewGuid()) };
+        await projector.WhenAsync(new CrewAssigned(new MissionId(missionId), crewIds));
+
+        var mission = service.GetById(missionId)!;
+        Assert.Equal(2, mission.CrewMemberIds.Count);
+        Assert.Contains(crewIds[0].Value, mission.CrewMemberIds);
+        Assert.Contains(crewIds[1].Value, mission.CrewMemberIds);
+    }
+}

--- a/example/RocketLaunch.ReadModel.Tests/StationAvailabilityServiceTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/StationAvailabilityServiceTests.cs
@@ -12,7 +12,8 @@ public class StationAvailabilityServiceTests
     {
         var rocketService = new InMemoryRocketService();
         var padService = new InMemoryLaunchPadService();
-        var crewService = new InMemoryCrewService();
+        var missionService = new InMemoryMissionService();
+        var crewService = new InMemoryCrewService(missionService);
         var sut = new InMemoryStationAvailabilityService(rocketService, padService, crewService);
 
         var rocketId = Guid.NewGuid();
@@ -33,7 +34,8 @@ public class StationAvailabilityServiceTests
     public async Task IsRocketAvailable_returns_false_when_not_available()
     {
         var rocketService = new InMemoryRocketService();
-        var sut = new InMemoryStationAvailabilityService(rocketService, new InMemoryLaunchPadService(), new InMemoryCrewService());
+        var missionService = new InMemoryMissionService();
+        var sut = new InMemoryStationAvailabilityService(rocketService, new InMemoryLaunchPadService(), new InMemoryCrewService(missionService));
 
         var rocketId = Guid.NewGuid();
         await rocketService.CreateOrUpdateAsync(new Rocket
@@ -55,7 +57,8 @@ public class StationAvailabilityServiceTests
     {
         var rocketService = new InMemoryRocketService();
         var padService = new InMemoryLaunchPadService();
-        var crewService = new InMemoryCrewService();
+        var missionService = new InMemoryMissionService();
+        var crewService = new InMemoryCrewService(missionService);
         var sut = new InMemoryStationAvailabilityService(rocketService, padService, crewService);
 
         var padId = Guid.NewGuid();
@@ -77,7 +80,8 @@ public class StationAvailabilityServiceTests
     public async Task IsLaunchPadAvailable_returns_false_when_overlap()
     {
         var padService = new InMemoryLaunchPadService();
-        var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), padService, new InMemoryCrewService());
+        var missionService = new InMemoryMissionService();
+        var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), padService, new InMemoryCrewService(missionService));
 
         var padId = Guid.NewGuid();
         var window1 = new LaunchWindow(DateTime.UtcNow.AddHours(1), DateTime.UtcNow.AddHours(2));
@@ -105,7 +109,8 @@ public class StationAvailabilityServiceTests
     [Fact]
     public async Task AreCrewMembersAvailable_returns_true_when_all_available()
     {
-        var crewService = new InMemoryCrewService();
+        var missionService = new InMemoryMissionService();
+        var crewService = new InMemoryCrewService(missionService);
         var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), new InMemoryLaunchPadService(), crewService);
 
         var id1 = Guid.NewGuid();
@@ -122,7 +127,8 @@ public class StationAvailabilityServiceTests
     [Fact]
     public async Task AreCrewMembersAvailable_returns_false_when_any_unavailable()
     {
-        var crewService = new InMemoryCrewService();
+        var missionService = new InMemoryMissionService();
+        var crewService = new InMemoryCrewService(missionService);
         var sut = new InMemoryStationAvailabilityService(new InMemoryRocketService(), new InMemoryLaunchPadService(), crewService);
 
         var id1 = Guid.NewGuid();


### PR DESCRIPTION
## Summary
- add Mission read model and service
- implement MissionProjector to handle mission events
- implement CrewMemberProjector event handlers
- update InMemoryCrewService to query missions
- register new services/projector in API
- add tests for MissionProjector and CrewMemberProjector

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687288e3f0208328973bc7030d4666da