### PR TITLE
Expose mission and crew queries

### DIFF
--- a/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
@@ -83,6 +83,8 @@ internal static class CrewMemberRequestHandler
             var crew = service.GetById(crewMemberId);
             return crew is null ? Results.NotFound() : Results.Ok(crew);
         });
+
+        app.MapGet("/crew-members", ([FromServices] ICrewMemberService service) => Results.Ok(service.GetAll()));
     }
 }
 

--- a/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
@@ -67,6 +67,14 @@ internal static class MissionRequestHandler
             return result.IsSuccess ? Results.Ok() : Results.BadRequest(result.FailReason);
         });
 
+        app.MapGet("/missions/{missionId:guid}", ([FromServices] IMissionService service, [FromRoute] Guid missionId) =>
+        {
+            var mission = service.GetById(missionId);
+            return mission is null ? Results.NotFound() : Results.Ok(mission);
+        });
+
+        app.MapGet("/missions", ([FromServices] IMissionService service) => Results.Ok(service.GetAll()));
+
         app.MapGet("/rockets/{id:guid}", ([FromServices] IRocketService service, [FromRoute] Guid id) =>
         {
             var rocket = service.GetById(id);

--- a/example/RocketLaunch.ReadModel.Core/Service/ICrewMemberService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/ICrewMemberService.cs
@@ -5,6 +5,7 @@ namespace RocketLaunch.ReadModel.Core.Service;
 public interface ICrewMemberService
 {
     CrewMember? GetById(Guid crewMemberId);
+    IEnumerable<CrewMember> GetAll();
 
     /// <summary>
     /// Returns true if the crew member is available and certified for a given role

--- a/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
@@ -5,5 +5,6 @@ namespace RocketLaunch.ReadModel.Core.Service;
 public interface IMissionService
 {
     Mission? GetById(Guid missionId);
+    IEnumerable<Mission> GetAll();
     Task CreateOrUpdateAsync(Mission mission);
 }

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryCrewService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryCrewService.cs
@@ -15,6 +15,11 @@ namespace RocketLaunch.ReadModel.InMemory.Service
             return member;
         }
 
+        public IEnumerable<CrewMember> GetAll()
+        {
+            return _crew.Values;
+        }
+
         public bool IsAvailable(Guid crewMemberId, string requiredRole)
         {
             if (!_crew.TryGetValue(crewMemberId, out var member))

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
@@ -14,6 +14,11 @@ public class InMemoryMissionService : IMissionService
         return mission;
     }
 
+    public IEnumerable<Mission> GetAll()
+    {
+        return _missions.Values;
+    }
+
     public Task CreateOrUpdateAsync(Mission mission)
     {
         _missions[mission.MissionId] = mission;


### PR DESCRIPTION
## Summary
- add retrieval endpoints for Missions and CrewMembers
- extend read model services with `GetAll`
- implement retrieval for in-memory services

## Testing
- `dotnet build --no-incremental -v minimal`
- `dotnet test example/RocketLaunch.ReadModel.Tests/RocketLaunch.ReadModel.Tests.csproj --no-build -v minimal`
- `dotnet test example/RocketLaunch.Application.Tests/RocketLaunch.Application.Tests.csproj --no-build -v minimal`
- `dotnet test test/DDD.BuildingBlocks.MSSQLPackage.Tests.Integration/DDD.BuildingBlocks.MSSQLPackage.Tests.Integration.csproj --no-build -v minimal` *(fails: Docker unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6872975c873c83289307f4edc6d7aab8