### PR TITLE
Add read endpoints for rockets and launchpads

### DIFF
--- a/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using RocketLaunch.ReadModel.Core.Service;
+
+namespace RocketLaunch.Api.Handler;
+
+internal static class EntityRequestHandler
+{
+    internal static void MapEntityRoutes(this WebApplication app)
+    {
+        var group = app.MapGroup("entities")
+            .WithTags("Entities");
+
+        group.MapGet("/rockets/{rocketId:guid}", ([FromServices] IRocketService service, [FromRoute] Guid rocketId) =>
+        {
+            var rocket = service.GetById(rocketId);
+            return rocket is null ? Results.NotFound() : Results.Ok(rocket);
+        });
+
+        group.MapGet("/rockets", ([FromServices] IRocketService service) => Results.Ok(service.GetAll()));
+
+        group.MapGet("/launchpads/{padId:guid}", ([FromServices] ILaunchPadService service, [FromRoute] Guid padId) =>
+        {
+            var pad = service.GetById(padId);
+            return pad is null ? Results.NotFound() : Results.Ok(pad);
+        });
+
+        group.MapGet("/launchpads", ([FromServices] ILaunchPadService service) => Results.Ok(service.GetAll()));
+    }
+}

--- a/example/RocketLaunch.Api/Program.cs
+++ b/example/RocketLaunch.Api/Program.cs
@@ -150,6 +150,7 @@ app.UseSwaggerUI();
 // Minimal API endpoints
 app.MapMissionRoutes();
 app.MapCrewMemberRoutes();
+app.MapEntityRoutes();
 
 app.Run();
 

--- a/example/RocketLaunch.ReadModel.Core/Service/ILaunchPadService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/ILaunchPadService.cs
@@ -5,6 +5,7 @@ namespace RocketLaunch.ReadModel.Core.Service;
 public interface ILaunchPadService
 {
     LaunchPad? GetById(Guid padId);
+    IEnumerable<LaunchPad> GetAll();
 
     /// <summary>
     /// Returns true if the launch pad is available for the given time window

--- a/example/RocketLaunch.ReadModel.Core/Service/IRocketService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/IRocketService.cs
@@ -5,6 +5,7 @@ namespace RocketLaunch.ReadModel.Core.Service;
 public interface IRocketService
 {
     Rocket? GetById(Guid rocketId);
+    IEnumerable<Rocket> GetAll();
 
     /// <summary>
     /// Returns true if the rocket is available (e.g., not assigned, not in maintenance)

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryLaunchPadService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryLaunchPadService.cs
@@ -14,6 +14,11 @@ namespace RocketLaunch.ReadModel.InMemory.Service
             return pad;
         }
 
+        public IEnumerable<LaunchPad> GetAll()
+        {
+            return _pads.Values;
+        }
+
         public bool IsAvailable(Guid padId, DateTime windowStart, DateTime windowEnd)
         {
             var pad = GetById(padId);

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
@@ -14,6 +14,11 @@ namespace RocketLaunch.ReadModel.InMemory.Service
             return rocket;
         }
 
+        public IEnumerable<Rocket> GetAll()
+        {
+            return _rockets.Values;
+        }
+
         public Rocket? FindByAssignedMission(Guid missionId)
         {
             return _rockets.Values.FirstOrDefault(r => r.AssignedMissionId == missionId);

--- a/example/RocketLaunch.ReadModel.Tests/EntityServiceTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/EntityServiceTests.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using RocketLaunch.ReadModel.Core.Model;
+using RocketLaunch.ReadModel.InMemory.Service;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class EntityServiceTests
+{
+    [Fact]
+    public async Task RocketService_returns_all_rockets()
+    {
+        var service = new InMemoryRocketService();
+        await service.CreateOrUpdateAsync(new Rocket { RocketId = Guid.NewGuid(), Name = "A" });
+        await service.CreateOrUpdateAsync(new Rocket { RocketId = Guid.NewGuid(), Name = "B" });
+
+        var all = service.GetAll().ToList();
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, r => r.Name == "A");
+        Assert.Contains(all, r => r.Name == "B");
+    }
+
+    [Fact]
+    public async Task LaunchPadService_returns_all_pads()
+    {
+        var service = new InMemoryLaunchPadService();
+        await service.CreateOrUpdateAsync(new LaunchPad { LaunchPadId = Guid.NewGuid(), PadName = "P1" });
+        await service.CreateOrUpdateAsync(new LaunchPad { LaunchPadId = Guid.NewGuid(), PadName = "P2" });
+
+        var all = service.GetAll().ToList();
+        Assert.Equal(2, all.Count);
+        Assert.Contains(all, p => p.PadName == "P1");
+        Assert.Contains(all, p => p.PadName == "P2");
+    }
+}


### PR DESCRIPTION
## Summary
- expose rocket and launchpad read endpoints under new `entities` group
- extend read model interfaces to provide `GetAll`
- implement `GetAll` in in-memory services
- add unit tests for the new service methods

## Testing
- `dotnet test` *(fails: Docker not running)*

------
https://chatgpt.com/codex/tasks/task_e_687391fec9808328bf81666ed36200b5