### PR TITLE
Add async to read model services

### DIFF
--- a/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
@@ -50,13 +50,13 @@ internal static class CrewMemberRequestHandler
             return result.IsSuccess ? Results.Ok() : Results.BadRequest(result.FailReason);
         });
 
-        group.MapGet("/{crewMemberId:guid}", ([FromServices] ICrewMemberService service, [FromRoute] Guid crewMemberId) =>
+        group.MapGet("/{crewMemberId:guid}", async ([FromServices] ICrewMemberService service, [FromRoute] Guid crewMemberId) =>
         {
-            var crew = service.GetById(crewMemberId);
+            var crew = await service.GetByIdAsync(crewMemberId);
             return crew is null ? Results.NotFound() : Results.Ok(crew);
         });
 
-        group.MapGet("/", ([FromServices] ICrewMemberService service) => Results.Ok(service.GetAll()));
+        group.MapGet("/", async ([FromServices] ICrewMemberService service) => Results.Ok(await service.GetAllAsync()));
     }
 }
 

--- a/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
@@ -10,20 +10,19 @@ internal static class EntityRequestHandler
         var group = app.MapGroup("entities")
             .WithTags("Entities");
 
-        group.MapGet("/rockets/{rocketId:guid}", ([FromServices] IRocketService service, [FromRoute] Guid rocketId) =>
+        group.MapGet("/rockets/{rocketId:guid}", async ([FromServices] IRocketService service, [FromRoute] Guid rocketId) =>
         {
-            var rocket = service.GetById(rocketId);
+            var rocket = await service.GetByIdAsync(rocketId);
             return rocket is null ? Results.NotFound() : Results.Ok(rocket);
         });
 
-        group.MapGet("/rockets", ([FromServices] IRocketService service) => Results.Ok(service.GetAll()));
+        group.MapGet("/rockets", async ([FromServices] IRocketService service) => Results.Ok(await service.GetAllAsync()));
 
-        group.MapGet("/launchpads/{padId:guid}", ([FromServices] ILaunchPadService service, [FromRoute] Guid padId) =>
+        group.MapGet("/launchpads/{padId:guid}", async ([FromServices] ILaunchPadService service, [FromRoute] Guid padId) =>
         {
-            var pad = service.GetById(padId);
+            var pad = await service.GetByIdAsync(padId);
             return pad is null ? Results.NotFound() : Results.Ok(pad);
         });
-
-        group.MapGet("/launchpads", ([FromServices] ILaunchPadService service) => Results.Ok(service.GetAll()));
+        group.MapGet("/launchpads", async ([FromServices] ILaunchPadService service) => Results.Ok(await service.GetAllAsync()));
     }
 }

--- a/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
@@ -70,17 +70,17 @@ internal static class MissionRequestHandler
             return result.IsSuccess ? Results.Ok() : Results.BadRequest(result.FailReason);
         });
 
-        group.MapGet("/{missionId:guid}", ([FromServices] IMissionService service, [FromRoute] Guid missionId) =>
+        group.MapGet("/{missionId:guid}", async ([FromServices] IMissionService service, [FromRoute] Guid missionId) =>
         {
-            var mission = service.GetById(missionId);
+            var mission = await service.GetByIdAsync(missionId);
             return mission is null ? Results.NotFound() : Results.Ok(mission);
         });
 
-        group.MapGet("/", ([FromServices] IMissionService service) => Results.Ok(service.GetAll()));
+        group.MapGet("/", async ([FromServices] IMissionService service) => Results.Ok(await service.GetAllAsync()));
 
-        group.MapGet("/rockets/{id:guid}", ([FromServices] IRocketService service, [FromRoute] Guid id) =>
+        group.MapGet("/rockets/{id:guid}", async ([FromServices] IRocketService service, [FromRoute] Guid id) =>
         {
-            var rocket = service.GetById(id);
+            var rocket = await service.GetByIdAsync(id);
             return rocket is null ? Results.NotFound() : Results.Ok(rocket);
         });
     }

--- a/example/RocketLaunch.ReadModel.Core/Projector/CrewMember/CrewMemberProjector.cs
+++ b/example/RocketLaunch.ReadModel.Core/Projector/CrewMember/CrewMemberProjector.cs
@@ -21,7 +21,7 @@ namespace RocketLaunch.ReadModel.Core.Projector.CrewMember
 
         public async Task WhenAsync(CrewMemberAssigned @event)
         {
-            var member = _crewService.GetById(@event.CrewMemberId.Value);
+            var member = await _crewService.GetByIdAsync(@event.CrewMemberId.Value);
             if (member == null)
             {
                 _logger.LogWarning("Crew member {CrewMemberId} not found for assignment", @event.CrewMemberId);
@@ -34,7 +34,7 @@ namespace RocketLaunch.ReadModel.Core.Projector.CrewMember
 
         public async Task WhenAsync(CrewMemberCertificationSet @event)
         {
-            var member = _crewService.GetById(@event.CrewMemberId.Value);
+            var member = await _crewService.GetByIdAsync(@event.CrewMemberId.Value);
             if (member == null)
             {
                 _logger.LogWarning("Crew member {CrewMemberId} not found for certification update", @event.CrewMemberId);
@@ -61,7 +61,7 @@ namespace RocketLaunch.ReadModel.Core.Projector.CrewMember
 
         public async Task WhenAsync(CrewMemberReleased @event)
         {
-            var member = _crewService.GetById(@event.CrewMemberId.Value);
+            var member = await _crewService.GetByIdAsync(@event.CrewMemberId.Value);
             if (member == null)
             {
                 _logger.LogWarning("Crew member {CrewMemberId} not found for release", @event.CrewMemberId);
@@ -74,7 +74,7 @@ namespace RocketLaunch.ReadModel.Core.Projector.CrewMember
 
         public async Task WhenAsync(CrewMemberStatusSet @event)
         {
-            var member = _crewService.GetById(@event.CrewMemberId.Value);
+            var member = await _crewService.GetByIdAsync(@event.CrewMemberId.Value);
             if (member == null)
             {
                 _logger.LogWarning("Crew member {CrewMemberId} not found for status change", @event.CrewMemberId);

--- a/example/RocketLaunch.ReadModel.Core/Projector/Mission/LaunchPadProjector.cs
+++ b/example/RocketLaunch.ReadModel.Core/Projector/Mission/LaunchPadProjector.cs
@@ -16,7 +16,7 @@ public class LaunchPadProjector(ILaunchPadService padService, ILogger<LaunchPadP
 
     public async Task WhenAsync(LaunchPadAssigned @event)
     {
-        var pad = _padService.GetById(@event.PadId.Value) ?? new LaunchPad
+        var pad = await _padService.GetByIdAsync(@event.PadId.Value) ?? new LaunchPad
         {
             LaunchPadId = @event.PadId.Value,
             PadName = @event.Name,
@@ -51,7 +51,7 @@ public class LaunchPadProjector(ILaunchPadService padService, ILogger<LaunchPadP
 
     public async Task WhenAsync(MissionAborted @event)
     {
-        var pad = _padService.FindByAssignedMission(@event.MissionId.Value);
+        var pad = await _padService.FindByAssignedMissionAsync(@event.MissionId.Value);
 
         if (pad == null)
         {
@@ -70,7 +70,7 @@ public class LaunchPadProjector(ILaunchPadService padService, ILogger<LaunchPadP
         
     public async Task WhenAsync(MissionLaunched @event)
     {
-        var pad = _padService.FindByAssignedMission(@event.MissionId.Value);
+        var pad = await _padService.FindByAssignedMissionAsync(@event.MissionId.Value);
 
         if (pad == null)
         {

--- a/example/RocketLaunch.ReadModel.Core/Projector/Mission/MissionProjector.cs
+++ b/example/RocketLaunch.ReadModel.Core/Projector/Mission/MissionProjector.cs
@@ -38,7 +38,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(RocketAssigned @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for RocketAssigned", @event.MissionId);
@@ -51,7 +51,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(LaunchPadAssigned @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for LaunchPadAssigned", @event.MissionId);
@@ -67,7 +67,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(CrewAssigned @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for CrewAssigned", @event.MissionId);
@@ -87,7 +87,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(MissionScheduled @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for MissionScheduled", @event.MissionId);
@@ -100,7 +100,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(MissionAborted @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for MissionAborted", @event.MissionId);
@@ -113,7 +113,7 @@ public class MissionProjector(IMissionService missionService, ILogger<MissionPro
 
     public async Task WhenAsync(MissionLaunched @event)
     {
-        var mission = _missionService.GetById(@event.MissionId.Value);
+        var mission = await _missionService.GetByIdAsync(@event.MissionId.Value);
         if (mission == null)
         {
             _logger.LogWarning("Mission {MissionId} not found for MissionLaunched", @event.MissionId);

--- a/example/RocketLaunch.ReadModel.Core/Projector/Mission/RocketProjector.cs
+++ b/example/RocketLaunch.ReadModel.Core/Projector/Mission/RocketProjector.cs
@@ -16,7 +16,7 @@ public class RocketProjector(IRocketService rocketService, ILogger<RocketProject
 
     public async Task WhenAsync(RocketAssigned @event)
     {
-        var rocket = _rocketService.GetById(@event.RocketId.Value) ?? new Rocket
+        var rocket = await _rocketService.GetByIdAsync(@event.RocketId.Value) ?? new Rocket
         {
             RocketId = @event.RocketId.Value,
             Name = @event.Name,
@@ -35,7 +35,7 @@ public class RocketProjector(IRocketService rocketService, ILogger<RocketProject
     public async Task WhenAsync(MissionAborted @event)
     {
         // Find the rocket that was assigned to this mission
-        var rocket = _rocketService.FindByAssignedMission(@event.MissionId.Value);
+        var rocket = await _rocketService.FindByAssignedMissionAsync(@event.MissionId.Value);
 
         if (rocket == null)
         {

--- a/example/RocketLaunch.ReadModel.Core/Service/ICrewMemberService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/ICrewMemberService.cs
@@ -4,25 +4,25 @@ namespace RocketLaunch.ReadModel.Core.Service;
 
 public interface ICrewMemberService
 {
-    CrewMember? GetById(Guid crewMemberId);
-    IEnumerable<CrewMember> GetAll();
+    Task<CrewMember?> GetByIdAsync(Guid crewMemberId);
+    Task<IEnumerable<CrewMember>> GetAllAsync();
 
     /// <summary>
     /// Returns true if the crew member is available and certified for a given role
     /// </summary>
-    bool IsAvailable(Guid crewMemberId, string requiredRole);
+    Task<bool> IsAvailableAsync(Guid crewMemberId, string requiredRole);
 
     /// <summary>
     /// Finds all available crew with a specific role and/or certification
     /// </summary>
-    IEnumerable<CrewMember> FindAvailable(string role, string? certification = null);
+    Task<IEnumerable<CrewMember>> FindAvailableAsync(string role, string? certification = null);
     
     /// <summary>
     /// Finds all crew members that are available for a specific mission
     /// </summary>
     /// <param name="missionId"></param>
     /// <returns></returns>
-    IEnumerable<CrewMember> FindByAssignedMission(Guid missionId);
+    Task<IEnumerable<CrewMember>> FindByAssignedMissionAsync(Guid missionId);
     
     /// <summary>
     /// Creates or updates a crew member in the read model

--- a/example/RocketLaunch.ReadModel.Core/Service/ILaunchPadService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/ILaunchPadService.cs
@@ -4,25 +4,25 @@ namespace RocketLaunch.ReadModel.Core.Service;
 
 public interface ILaunchPadService
 {
-    LaunchPad? GetById(Guid padId);
-    IEnumerable<LaunchPad> GetAll();
+    Task<LaunchPad?> GetByIdAsync(Guid padId);
+    Task<IEnumerable<LaunchPad>> GetAllAsync();
 
     /// <summary>
     /// Returns true if the launch pad is available for the given time window
     /// </summary>
-    bool IsAvailable(Guid padId, DateTime windowStart, DateTime windowEnd);
+    Task<bool> IsAvailableAsync(Guid padId, DateTime windowStart, DateTime windowEnd);
 
     /// <summary>
     /// Finds all launch pads that support the given rocket type and are free for the time window
     /// </summary>
-    IEnumerable<LaunchPad> FindAvailable(string rocketType, DateTime windowStart, DateTime windowEnd);
+    Task<IEnumerable<LaunchPad>> FindAvailableAsync(string rocketType, DateTime windowStart, DateTime windowEnd);
     
     /// <summary>
     /// Find a launch pad that is currently assigned to a specific mission
     /// </summary>
     /// <param name="missionId"></param>
     /// <returns></returns>
-    LaunchPad? FindByAssignedMission(Guid missionId);
+    Task<LaunchPad?> FindByAssignedMissionAsync(Guid missionId);
     
     /// <summary>
     /// Updates the launch pad information in the read model

--- a/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/IMissionService.cs
@@ -4,7 +4,7 @@ namespace RocketLaunch.ReadModel.Core.Service;
 
 public interface IMissionService
 {
-    Mission? GetById(Guid missionId);
-    IEnumerable<Mission> GetAll();
+    Task<Mission?> GetByIdAsync(Guid missionId);
+    Task<IEnumerable<Mission>> GetAllAsync();
     Task CreateOrUpdateAsync(Mission mission);
 }

--- a/example/RocketLaunch.ReadModel.Core/Service/IRocketService.cs
+++ b/example/RocketLaunch.ReadModel.Core/Service/IRocketService.cs
@@ -4,18 +4,18 @@ namespace RocketLaunch.ReadModel.Core.Service;
 
 public interface IRocketService
 {
-    Rocket? GetById(Guid rocketId);
-    IEnumerable<Rocket> GetAll();
+    Task<Rocket?> GetByIdAsync(Guid rocketId);
+    Task<IEnumerable<Rocket>> GetAllAsync();
 
     /// <summary>
     /// Returns true if the rocket is available (e.g., not assigned, not in maintenance)
     /// </summary>
-    bool IsAvailable(Guid rocketId);
+    Task<bool> IsAvailableAsync(Guid rocketId);
 
     /// <summary>
     /// Returns all available rockets with at least the given payload and crew capacity
     /// </summary>
-    IEnumerable<Rocket> FindAvailable(int minPayloadKg, int minCrewCapacity);
+    Task<IEnumerable<Rocket>> FindAvailableAsync(int minPayloadKg, int minCrewCapacity);
     
     /// <summary>
     /// Saves a new rocket to the read model
@@ -29,7 +29,7 @@ public interface IRocketService
     /// </summary>
     /// <param name="missionId"></param>
     /// <returns></returns>
-    Rocket? FindByAssignedMission(Guid missionId);
+    Task<Rocket?> FindByAssignedMissionAsync(Guid missionId);
 
 
 }

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
@@ -8,15 +8,15 @@ public class InMemoryMissionService : IMissionService
 {
     private readonly ConcurrentDictionary<Guid, Mission> _missions = new();
 
-    public Mission? GetById(Guid missionId)
+    public Task<Mission?> GetByIdAsync(Guid missionId)
     {
         _missions.TryGetValue(missionId, out var mission);
-        return mission;
+        return Task.FromResult(mission);
     }
 
-    public IEnumerable<Mission> GetAll()
+    public Task<IEnumerable<Mission>> GetAllAsync()
     {
-        return _missions.Values;
+        return Task.FromResult<IEnumerable<Mission>>(_missions.Values);
     }
 
     public Task CreateOrUpdateAsync(Mission mission)

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
@@ -8,36 +8,38 @@ namespace RocketLaunch.ReadModel.InMemory.Service
     {
         private readonly ConcurrentDictionary<Guid, Rocket> _rockets = new();
 
-        public Rocket? GetById(Guid rocketId)
+        public Task<Rocket?> GetByIdAsync(Guid rocketId)
         {
             _rockets.TryGetValue(rocketId, out var rocket);
-            return rocket;
+            return Task.FromResult(rocket);
         }
 
-        public IEnumerable<Rocket> GetAll()
+        public Task<IEnumerable<Rocket>> GetAllAsync()
         {
-            return _rockets.Values;
+            return Task.FromResult<IEnumerable<Rocket>>(_rockets.Values);
         }
 
-        public Rocket? FindByAssignedMission(Guid missionId)
+        public Task<Rocket?> FindByAssignedMissionAsync(Guid missionId)
         {
-            return _rockets.Values.FirstOrDefault(r => r.AssignedMissionId == missionId);
+            var rocket = _rockets.Values.FirstOrDefault(r => r.AssignedMissionId == missionId);
+            return Task.FromResult(rocket);
         }
-        
-        public bool IsAvailable(Guid rocketId)
+
+        public async Task<bool> IsAvailableAsync(Guid rocketId)
         {
-            var rocket = GetById(rocketId);
+            var rocket = await GetByIdAsync(rocketId);
             if (rocket == null)
                 return false;
             return rocket.Status == RocketStatus.Available;
         }
 
-        public IEnumerable<Rocket> FindAvailable(int minPayloadKg, int minCrewCapacity)
+        public Task<IEnumerable<Rocket>> FindAvailableAsync(int minPayloadKg, int minCrewCapacity)
         {
-            return _rockets.Values.Where(r =>
+            var result = _rockets.Values.Where(r =>
                 r.Status == RocketStatus.Available &&
                 r.PayloadCapacityKg >= minPayloadKg &&
                 r.CrewCapacity >= minCrewCapacity);
+            return Task.FromResult<IEnumerable<Rocket>>(result);
         }
 
         public Task CreateOrUpdateAsync(Rocket rocket)

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryStationAvailabilityService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryStationAvailabilityService.cs
@@ -11,22 +11,20 @@ namespace RocketLaunch.ReadModel.InMemory.Service
         ICrewMemberService crewService)
         : IResourceAvailabilityService
     {
-        public Task<bool> IsRocketAvailableAsync(RocketId rocketId, LaunchWindow window)
+        public async Task<bool> IsRocketAvailableAsync(RocketId rocketId, LaunchWindow window)
         {
-            return Task.FromResult(
-                rocketService.IsAvailable(rocketId.Value));
+            return await rocketService.IsAvailableAsync(rocketId.Value);
         }
 
-        public Task<bool> IsLaunchPadAvailableAsync(LaunchPadId padId, LaunchWindow window)
+        public async Task<bool> IsLaunchPadAvailableAsync(LaunchPadId padId, LaunchWindow window)
         {
-            return Task.FromResult(
-                padService.IsAvailable(padId.Value, window.Start, window.End));
+            return await padService.IsAvailableAsync(padId.Value, window.Start, window.End);
         }
 
-        public Task<bool> AreCrewMembersAvailableAsync(IEnumerable<CrewMemberId> crewIds, LaunchWindow window)
+        public async Task<bool> AreCrewMembersAvailableAsync(IEnumerable<CrewMemberId> crewIds, LaunchWindow window)
         {
-            return Task.FromResult(
-                !crewIds.Select(id => crewService.GetById(id.Value)).Any(member => member is not { Status: CrewMemberStatus.Available }));
+            var members = await Task.WhenAll(crewIds.Select(id => crewService.GetByIdAsync(id.Value)));
+            return members.All(member => member is { Status: CrewMemberStatus.Available });
         }
     }
 }

--- a/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/CrewMemberProjectorTests.cs
@@ -20,7 +20,7 @@ public class CrewMemberProjectorTests
         var memberId = Guid.NewGuid();
         await projector.WhenAsync(new CrewMemberRegistered(new CrewMemberId(memberId), "Alice", SharedKernel.Enums.CrewRole.Commander, ["Flight"]));
 
-        var member = service.GetById(memberId)!;
+        var member = (await service.GetByIdAsync(memberId))!;
         Assert.Equal("Alice", member.Name);
         Assert.Equal(CrewMemberStatus.Available, member.Status);
     }
@@ -37,7 +37,7 @@ public class CrewMemberProjectorTests
 
         await projector.WhenAsync(new CrewMemberAssigned(new CrewMemberId(memberId)));
 
-        var member = service.GetById(memberId)!;
+        var member = (await service.GetByIdAsync(memberId))!;
         Assert.Equal(CrewMemberStatus.Assigned, member.Status);
     }
 }

--- a/example/RocketLaunch.ReadModel.Tests/EntityServiceTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/EntityServiceTests.cs
@@ -14,7 +14,7 @@ public class EntityServiceTests
         await service.CreateOrUpdateAsync(new Rocket { RocketId = Guid.NewGuid(), Name = "A" });
         await service.CreateOrUpdateAsync(new Rocket { RocketId = Guid.NewGuid(), Name = "B" });
 
-        var all = service.GetAll().ToList();
+        var all = (await service.GetAllAsync()).ToList();
         Assert.Equal(2, all.Count);
         Assert.Contains(all, r => r.Name == "A");
         Assert.Contains(all, r => r.Name == "B");
@@ -27,7 +27,7 @@ public class EntityServiceTests
         await service.CreateOrUpdateAsync(new LaunchPad { LaunchPadId = Guid.NewGuid(), PadName = "P1" });
         await service.CreateOrUpdateAsync(new LaunchPad { LaunchPadId = Guid.NewGuid(), PadName = "P2" });
 
-        var all = service.GetAll().ToList();
+        var all = (await service.GetAllAsync()).ToList();
         Assert.Equal(2, all.Count);
         Assert.Contains(all, p => p.PadName == "P1");
         Assert.Contains(all, p => p.PadName == "P2");

--- a/example/RocketLaunch.ReadModel.Tests/LaunchPadProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/LaunchPadProjectorTests.cs
@@ -32,7 +32,7 @@ public class LaunchPadProjectorTests
             new LaunchPadAssigned(
                 new MissionId(missionId), new LaunchPadId(padId), "Launch Pad M-1", "Cape Carnival", ["Falcon 9"], window));
 
-        var pad = service.GetById(padId)!;
+        var pad = (await service.GetByIdAsync(padId))!;
         Assert.Equal(LaunchPadStatus.Occupied, pad.Status);
         Assert.Single(pad.OccupiedWindows);
         var scheduled = pad.OccupiedWindows[0];
@@ -68,7 +68,7 @@ public class LaunchPadProjectorTests
 
         await projector.WhenAsync(new MissionAborted(new MissionId(missionId)));
 
-        var pad = service.GetById(padId)!;
+        var pad = (await service.GetByIdAsync(padId))!;
         Assert.Equal(LaunchPadStatus.Available, pad.Status);
         Assert.Empty(pad.OccupiedWindows);
     }
@@ -100,7 +100,7 @@ public class LaunchPadProjectorTests
 
         await projector.WhenAsync(new MissionLaunched(new MissionId(missionId)));
 
-        var pad = service.GetById(padId)
+        var pad = (await service.GetByIdAsync(padId))
             ?? throw new InvalidOperationException("Launch pad not found");
         Assert.Equal(LaunchPadStatus.Available, pad.Status);
         Assert.Empty(pad.OccupiedWindows);

--- a/example/RocketLaunch.ReadModel.Tests/MissionProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/MissionProjectorTests.cs
@@ -20,7 +20,7 @@ public class MissionProjectorTests
         var window = new LaunchWindow(DateTime.UtcNow, DateTime.UtcNow.AddHours(1));
         await projector.WhenAsync(new MissionCreated(new MissionId(missionId), new MissionName("Test"), new TargetOrbit("LEO"), new PayloadDescription("Sat"), window));
 
-        var mission = service.GetById(missionId)!;
+        var mission = (await service.GetByIdAsync(missionId))!;
         Assert.Equal("Test", mission.Name);
         Assert.Equal(MissionStatus.Planned, mission.Status);
         Assert.Equal(window.Start, mission.LaunchWindowStart);
@@ -38,7 +38,7 @@ public class MissionProjectorTests
         var crewIds = new[] { new CrewMemberId(Guid.NewGuid()), new CrewMemberId(Guid.NewGuid()) };
         await projector.WhenAsync(new CrewAssigned(new MissionId(missionId), crewIds));
 
-        var mission = service.GetById(missionId)!;
+        var mission = (await service.GetByIdAsync(missionId))!;
         Assert.Equal(2, mission.CrewMemberIds.Count);
         Assert.Contains(crewIds[0].Value, mission.CrewMemberIds);
         Assert.Contains(crewIds[1].Value, mission.CrewMemberIds);

--- a/example/RocketLaunch.ReadModel.Tests/RocketProjectorTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/RocketProjectorTests.cs
@@ -30,7 +30,7 @@ public class RocketProjectorTests
             new RocketAssigned(
                 new MissionId(missionId), new RocketId(rocketId), "Falcon 9", 34.5, 140000, 3));
 
-        var rocket = service.GetById(rocketId)!;
+        var rocket = (await service.GetByIdAsync(rocketId))!;
         Assert.Equal(RocketStatus.Assigned, rocket.Status);
         Assert.Equal(missionId, rocket.AssignedMissionId);
     }
@@ -53,7 +53,7 @@ public class RocketProjectorTests
 
         await projector.WhenAsync(new MissionAborted(new MissionId(missionId)));
 
-        var rocket = service.GetById(rocketId)!;
+        var rocket = (await service.GetByIdAsync(rocketId))!;
         Assert.Equal(RocketStatus.Available, rocket.Status);
         Assert.Null(rocket.AssignedMissionId);
     }


### PR DESCRIPTION
## Summary
- convert read model service interfaces to async variants
- update in-memory service implementations
- adapt projectors and API handlers to await async methods
- update unit tests to call new async service methods

## Testing
- `dotnet test --no-build` *(fails: DDD.BuildingBlocks.MSSQLPackage.Tests.Integration due to missing Docker)*

------
https://chatgpt.com/codex/tasks/task_e_687396f7d4588328847be2e350c4457b