### PR TITLE
Add ID validation to in-memory services

### DIFF
--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryCrewService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryCrewService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using DDD.BuildingBlocks.Core.ErrorHandling;
+using RocketLaunch.ReadModel.Core.Exceptions;
 using RocketLaunch.ReadModel.Core.Model;
 using RocketLaunch.ReadModel.Core.Service;
 
@@ -11,6 +13,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<CrewMember?> GetByIdAsync(Guid id)
         {
+            if (id == Guid.Empty)
+                throw new ReadModelServiceException("Invalid crew member id", ErrorClassification.InputDataError);
+
             _crew.TryGetValue(id, out var member);
             return Task.FromResult(member);
         }
@@ -22,6 +27,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<bool> IsAvailableAsync(Guid crewMemberId, string requiredRole)
         {
+            if (crewMemberId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid crew member id", ErrorClassification.InputDataError);
+
             if (!_crew.TryGetValue(crewMemberId, out var member))
                 return Task.FromResult(false);
 
@@ -30,6 +38,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public async Task<IEnumerable<CrewMember>> FindByAssignedMissionAsync(Guid missionId)
         {
+            if (missionId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid mission id", ErrorClassification.InputDataError);
+
             var mission = await _missionService.GetByIdAsync(missionId);
             if (mission == null)
                 return [];

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryLaunchPadService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryLaunchPadService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using DDD.BuildingBlocks.Core.ErrorHandling;
+using RocketLaunch.ReadModel.Core.Exceptions;
 using RocketLaunch.ReadModel.Core.Model;
 using RocketLaunch.ReadModel.Core.Service;
 
@@ -10,6 +12,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<LaunchPad?> GetByIdAsync(Guid padId)
         {
+            if (padId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid launch pad id", ErrorClassification.InputDataError);
+
             _pads.TryGetValue(padId, out var pad);
             return Task.FromResult(pad);
         }
@@ -21,8 +26,11 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public async Task<bool> IsAvailableAsync(Guid padId, DateTime windowStart, DateTime windowEnd)
         {
+            if (padId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid launch pad id", ErrorClassification.InputDataError);
+
             var pad = await GetByIdAsync(padId);
-            
+
             if (pad == null)
                 return true;
             
@@ -37,6 +45,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<LaunchPad?> FindByAssignedMissionAsync(Guid missionId)
         {
+            if (missionId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid mission id", ErrorClassification.InputDataError);
+
             var pad = _pads.Values.FirstOrDefault(p =>
                 p.OccupiedWindows.Any(w => w.MissionId == missionId));
             return Task.FromResult(pad);

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryMissionService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using DDD.BuildingBlocks.Core.ErrorHandling;
+using RocketLaunch.ReadModel.Core.Exceptions;
 using RocketLaunch.ReadModel.Core.Model;
 using RocketLaunch.ReadModel.Core.Service;
 
@@ -10,6 +12,9 @@ public class InMemoryMissionService : IMissionService
 
     public Task<Mission?> GetByIdAsync(Guid missionId)
     {
+        if (missionId == Guid.Empty)
+            throw new ReadModelServiceException("Invalid mission id", ErrorClassification.InputDataError);
+
         _missions.TryGetValue(missionId, out var mission);
         return Task.FromResult(mission);
     }

--- a/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
+++ b/example/RocketLaunch.ReadModel.InMemory/Service/InMemoryRocketService.cs
@@ -1,4 +1,6 @@
 using System.Collections.Concurrent;
+using DDD.BuildingBlocks.Core.ErrorHandling;
+using RocketLaunch.ReadModel.Core.Exceptions;
 using RocketLaunch.ReadModel.Core.Model;
 using RocketLaunch.ReadModel.Core.Service;
 
@@ -10,6 +12,9 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<Rocket?> GetByIdAsync(Guid rocketId)
         {
+            if (rocketId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid rocket id", ErrorClassification.InputDataError);
+
             _rockets.TryGetValue(rocketId, out var rocket);
             return Task.FromResult(rocket);
         }
@@ -21,12 +26,18 @@ namespace RocketLaunch.ReadModel.InMemory.Service
 
         public Task<Rocket?> FindByAssignedMissionAsync(Guid missionId)
         {
+            if (missionId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid mission id", ErrorClassification.InputDataError);
+
             var rocket = _rockets.Values.FirstOrDefault(r => r.AssignedMissionId == missionId);
             return Task.FromResult(rocket);
         }
 
         public async Task<bool> IsAvailableAsync(Guid rocketId)
         {
+            if (rocketId == Guid.Empty)
+                throw new ReadModelServiceException("Invalid rocket id", ErrorClassification.InputDataError);
+
             var rocket = await GetByIdAsync(rocketId);
             if (rocket == null)
                 return true;

--- a/example/RocketLaunch.ReadModel.Tests/ServiceValidationTests.cs
+++ b/example/RocketLaunch.ReadModel.Tests/ServiceValidationTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using DDD.BuildingBlocks.Core.ErrorHandling;
+using RocketLaunch.ReadModel.Core.Exceptions;
+using RocketLaunch.ReadModel.InMemory.Service;
+using Xunit;
+
+namespace RocketLaunch.ReadModel.Tests;
+
+public class ServiceValidationTests
+{
+    [Fact]
+    public async Task RocketService_rejects_empty_id()
+    {
+        var service = new InMemoryRocketService();
+        var ex = await Assert.ThrowsAsync<ReadModelServiceException>(() => service.GetByIdAsync(Guid.Empty));
+        Assert.Equal(ErrorClassification.InputDataError, ex.ErrorInfo.Classification);
+    }
+
+    [Fact]
+    public async Task LaunchPadService_rejects_empty_id()
+    {
+        var service = new InMemoryLaunchPadService();
+        var ex = await Assert.ThrowsAsync<ReadModelServiceException>(() => service.GetByIdAsync(Guid.Empty));
+        Assert.Equal(ErrorClassification.InputDataError, ex.ErrorInfo.Classification);
+    }
+
+    [Fact]
+    public async Task MissionService_rejects_empty_id()
+    {
+        var service = new InMemoryMissionService();
+        var ex = await Assert.ThrowsAsync<ReadModelServiceException>(() => service.GetByIdAsync(Guid.Empty));
+        Assert.Equal(ErrorClassification.InputDataError, ex.ErrorInfo.Classification);
+    }
+
+    [Fact]
+    public async Task CrewService_rejects_empty_id()
+    {
+        var service = new InMemoryCrewService(new InMemoryMissionService());
+        var ex = await Assert.ThrowsAsync<ReadModelServiceException>(() => service.GetByIdAsync(Guid.Empty));
+        Assert.Equal(ErrorClassification.InputDataError, ex.ErrorInfo.Classification);
+    }
+}


### PR DESCRIPTION
## Summary
- guard against `Guid.Empty` in all in-memory read model services
- throw `ReadModelServiceException` with `InputDataError` when invalid IDs passed
- unit tests cover empty GUIDs for each service

## Testing
- `dotnet test DDD.BuildingBlocks.sln` *(fails: DDD.BuildingBlocks.MSSQLPackage.Tests.Integration)*

------
https://chatgpt.com/codex/tasks/task_e_6873d0d84cbc8328845716d9c2b8b5b9