### PR TITLE
Improve API error handling and extend tests

### DIFF
--- a/example/RocketLaunch.Api.Tests/ApiErrorTests.cs
+++ b/example/RocketLaunch.Api.Tests/ApiErrorTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace RocketLaunch.Api.Tests;
+
+public class ApiErrorTests : IClassFixture<RocketLaunchApiFactory>
+{
+    private readonly HttpClient _client;
+
+    public ApiErrorTests(RocketLaunchApiFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private record ErrorPayload(string Message, string Origin, string Classification);
+
+    [Fact]
+    public async Task GetMission_NotFound_Returns404()
+    {
+        var response = await _client.GetAsync($"/missions/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ScheduleMission_WithoutResources_ReturnsUnprocessableEntity()
+    {
+        var missionId = Guid.NewGuid();
+        var mission = new
+        {
+            MissionId = missionId,
+            MissionName = "Test",
+            TargetOrbit = "LEO",
+            PayloadDescription = "Sat",
+            LaunchWindowStart = DateTime.UtcNow,
+            LaunchWindowEnd = DateTime.UtcNow.AddHours(1)
+        };
+        var reg = await _client.PostAsJsonAsync("/missions/", mission);
+        reg.EnsureSuccessStatusCode();
+
+        var schedule = await _client.PostAsync($"/missions/{missionId}/schedule", null);
+        Assert.Equal((HttpStatusCode)422, schedule.StatusCode);
+
+        var payload = await schedule.Content.ReadFromJsonAsync<ErrorPayload>();
+        Assert.NotNull(payload);
+        Assert.Equal("ProcessingError", payload!.Classification);
+    }
+
+    [Fact]
+    public async Task GetRocket_InvalidId_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/entities/rockets/00000000-0000-0000-0000-000000000000");
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var payload = await response.Content.ReadFromJsonAsync<ErrorPayload>();
+        Assert.NotNull(payload);
+        Assert.Equal("InputDataError", payload!.Classification);
+    }
+}

--- a/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/CrewMemberRequestHandler.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
+using DDD.BuildingBlocks.Core.ErrorHandling;
 using RocketLaunch.Application;
 using RocketLaunch.Application.Command.CrewMember;
 using RocketLaunch.ReadModel.Core.Service;
@@ -53,8 +54,15 @@ internal static class CrewMemberRequestHandler
 
         group.MapGet("/{crewMemberId:guid}", async ([FromServices] ICrewMemberService service, [FromRoute] Guid crewMemberId) =>
         {
-            var crew = await service.GetByIdAsync(crewMemberId);
-            return crew is null ? Results.NotFound() : Results.Ok(crew);
+            try
+            {
+                var crew = await service.GetByIdAsync(crewMemberId);
+                return crew is null ? Results.NotFound() : Results.Ok(crew);
+            }
+            catch (ClassifiedErrorException ce)
+            {
+                return ce.ToApiResult();
+            }
         });
 
         group.MapGet("/", async ([FromServices] ICrewMemberService service) => Results.Ok(await service.GetAllAsync()));

--- a/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/EntityRequestHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using DDD.BuildingBlocks.Core.ErrorHandling;
 using RocketLaunch.ReadModel.Core.Service;
 
 namespace RocketLaunch.Api.Handler;
@@ -12,16 +13,30 @@ internal static class EntityRequestHandler
 
         group.MapGet("/rockets/{rocketId:guid}", async ([FromServices] IRocketService service, [FromRoute] Guid rocketId) =>
         {
-            var rocket = await service.GetByIdAsync(rocketId);
-            return rocket is null ? Results.NotFound() : Results.Ok(rocket);
+            try
+            {
+                var rocket = await service.GetByIdAsync(rocketId);
+                return rocket is null ? Results.NotFound() : Results.Ok(rocket);
+            }
+            catch (ClassifiedErrorException ce)
+            {
+                return ce.ToApiResult();
+            }
         });
 
         group.MapGet("/rockets", async ([FromServices] IRocketService service) => Results.Ok(await service.GetAllAsync()));
 
         group.MapGet("/launchpads/{padId:guid}", async ([FromServices] ILaunchPadService service, [FromRoute] Guid padId) =>
         {
-            var pad = await service.GetByIdAsync(padId);
-            return pad is null ? Results.NotFound() : Results.Ok(pad);
+            try
+            {
+                var pad = await service.GetByIdAsync(padId);
+                return pad is null ? Results.NotFound() : Results.Ok(pad);
+            }
+            catch (ClassifiedErrorException ce)
+            {
+                return ce.ToApiResult();
+            }
         });
         group.MapGet("/launchpads", async ([FromServices] ILaunchPadService service) => Results.Ok(await service.GetAllAsync()));
     }

--- a/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
+++ b/example/RocketLaunch.Api/Handler/MissionRequestHandler.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using DDD.BuildingBlocks.Core.ErrorHandling;
 using RocketLaunch.Application;
 using RocketLaunch.Application.Command.Mission;
 using RocketLaunch.Application.Dto;
@@ -73,16 +74,30 @@ internal static class MissionRequestHandler
 
         group.MapGet("/{missionId:guid}", async ([FromServices] IMissionService service, [FromRoute] Guid missionId) =>
         {
-            var mission = await service.GetByIdAsync(missionId);
-            return mission is null ? Results.NotFound() : Results.Ok(mission);
+            try
+            {
+                var mission = await service.GetByIdAsync(missionId);
+                return mission is null ? Results.NotFound() : Results.Ok(mission);
+            }
+            catch (ClassifiedErrorException ce)
+            {
+                return ce.ToApiResult();
+            }
         });
 
         group.MapGet("/", async ([FromServices] IMissionService service) => Results.Ok(await service.GetAllAsync()));
 
         group.MapGet("/rockets/{id:guid}", async ([FromServices] IRocketService service, [FromRoute] Guid id) =>
         {
-            var rocket = await service.GetByIdAsync(id);
-            return rocket is null ? Results.NotFound() : Results.Ok(rocket);
+            try
+            {
+                var rocket = await service.GetByIdAsync(id);
+                return rocket is null ? Results.NotFound() : Results.Ok(rocket);
+            }
+            catch (ClassifiedErrorException ce)
+            {
+                return ce.ToApiResult();
+            }
         });
     }
 }

--- a/example/RocketLaunch.Api/Handler/RequestHandlerExtensions.cs
+++ b/example/RocketLaunch.Api/Handler/RequestHandlerExtensions.cs
@@ -6,25 +6,33 @@ namespace RocketLaunch.Api.Handler;
 
 internal static class RequestHandlerExtensions
 {
+    private static IResult MapError(ClassifiedErrorException ce)
+    {
+        var payload = new { ce.ErrorInfo.Message, ce.ErrorInfo.Origin, ce.ErrorInfo.Classification };
+        return ce.ErrorInfo.Classification switch
+        {
+            ErrorClassification.NotFound => Results.NotFound(payload),
+            ErrorClassification.InputDataError => Results.BadRequest(payload),
+            ErrorClassification.ProcessingError => Results.UnprocessableEntity(payload),
+            ErrorClassification.InvalidState => Results.Conflict(payload),
+            ErrorClassification.TransientFailure => Results.StatusCode(StatusCodes.Status503ServiceUnavailable),
+            ErrorClassification.Infrastructure => Results.StatusCode(StatusCodes.Status503ServiceUnavailable),
+            ErrorClassification.ProgrammingError => Results.StatusCode(StatusCodes.Status500InternalServerError),
+            _ => Results.BadRequest(payload)
+        };
+    }
+
     internal static IResult ToApiResult(this ICommandExecutionResult execResult)
     {
         if (execResult.IsSuccess)
             return Results.Ok();
 
         if (execResult.ResultException is ClassifiedErrorException ce)
-        {
-            var payload = new { ce.ErrorInfo.Message, ce.ErrorInfo.Origin, ce.ErrorInfo.Classification };
-            return ce.ErrorInfo.Classification switch
-            {
-                ErrorClassification.NotFound => Results.NotFound(payload),
-                ErrorClassification.InputDataError => Results.BadRequest(payload),
-                ErrorClassification.ProcessingError => Results.UnprocessableEntity(payload),
-                ErrorClassification.Infrastructure => Results.StatusCode(StatusCodes.Status503ServiceUnavailable),
-                ErrorClassification.ProgrammingError => Results.StatusCode(StatusCodes.Status500InternalServerError),
-                _ => Results.BadRequest(payload)
-            };
-        }
+            return MapError(ce);
 
         return Results.BadRequest(new { Message = execResult.FailReason });
     }
+
+    internal static IResult ToApiResult(this ClassifiedErrorException ce)
+        => MapError(ce);
 }


### PR DESCRIPTION
## Summary
- map all `ClassifiedErrorException` variants to proper HTTP results
- handle classified errors in read model GET endpoints
- add integration tests for API error scenarios

## Testing
- `dotnet test example/RocketLaunch.Api.Tests/RocketLaunch.Api.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6873d88331ac83288e4fb6500bd138a4